### PR TITLE
OOCalc parser error

### DIFF
--- a/Classes/PHPExcel/Reader/OOCalc.php
+++ b/Classes/PHPExcel/Reader/OOCalc.php
@@ -597,6 +597,9 @@ class PHPExcel_Reader_OOCalc implements PHPExcel_Reader_IReader
 //										if ($hyperlink !== NULL) {
 //											echo 'Hyperlink is '.$hyperlink.'<br />';
 //										}
+									}else{
+										$type = PHPExcel_Cell_DataType::TYPE_NULL;
+										$dataValue = null;
 									}
 
 									if ($hasCalculatedValue) {


### PR DESCRIPTION
This error is triggered in OOCalc when parsing.

For example：
      A          B            C  
1  KEY       EN          CS  
2  hello       hello        你好! 
3  welcome                欢迎!

OOCalc after parser

C3 data becomes B3
For example：
      A          B            C  
1  KEY       EN          CS  
2  hello       hello        你好! 
3  welcome 欢迎!
