### PR TITLE
Change BORDER_NONE mapping In HTML writer. 

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -229,7 +229,7 @@ class PHPExcel_Writer_HTML implements PHPExcel_Writer_IWriter {
 	 */
 	private function _mapBorderStyle($borderStyle) {
 		switch ($borderStyle) {
-			case PHPExcel_Style_Border::BORDER_NONE:				return '0px solid';
+			case PHPExcel_Style_Border::BORDER_NONE:				return 'none';
 			case PHPExcel_Style_Border::BORDER_DASHDOT:				return '1px dashed';
 			case PHPExcel_Style_Border::BORDER_DASHDOTDOT:			return '1px dotted';
 			case PHPExcel_Style_Border::BORDER_DASHED:				return '1px dashed';


### PR DESCRIPTION
Based on http://www.css3.com/css-border-collapse/ the original '1px hidden' was causing borders to mysteriously disappear.

Specifically: If any shared border has a component where the ‘border’ is set to “hidden” for ANY of the sharing members, the common border should be unconditionally set to “hidden”.

I had originally tried '0px solid' instead, which worked fine in browsers, but when rendered to PDF from there the 0px borders were rendered as light-gray borders.  Using 'none' produces the ideal result of not overriding the adjacent cells' borders and also not rendering anything in pdf.
