### PR TITLE
Fix condition on existing file

### DIFF
--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -442,6 +442,10 @@ class PHPExcel_Reader_HTML implements PHPExcel_Reader_IReader
 			throw new Exception("Could not open " . $pFilename . " for reading! File does not exist.");
 		}
 
+		if (!is_file($pFilename)) {
+			throw new Exception("Could not open " . $pFilename . " for reading! The given file is not a regular file.");
+		}
+
 		// Create new PHPExcel
 		while ($objPHPExcel->getSheetCount() <= $this->_sheetIndex) {
 			$objPHPExcel->createSheet();


### PR DESCRIPTION
Hi,

When `$pFilename` point to a directory, `PHPExcel_Reader_HTML::loadIntoExisting()` method does not raise an exception. I think it should.
