### PR TITLE
add a basic composer configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ unitTests/codeCoverage
 
 *.buildpath
 *.project
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "phpoffice/phpexcel",
+    "description": "PHPExcel is a library that allow you to write to and read from different spreadsheet like Excel, Excel 2007, Libre/OpenOffice etc ...",
+    "keywords": ["office", "document", "spreadsheet", "excel"],
+    "license": "LGPL-2.1",
+    "homepage": "http://phpexcel.codeplex.com/",
+    "minimum-stability": "dev",
+    "authors": [
+        {
+            "name": "Maarten Balliauw",
+            "email": "maarten@phpexcel.net",
+            "homepage": "http://blog.maartenballiauw.be",
+            "role": "Manager/Developer"
+        },
+        {
+            "name": "Mark Baker",
+            "role": "Developer"
+        },
+        {
+            "name": "Erik Tilt",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+
+    },
+    "autoload": {
+        "classmap": ["Classes/"]
+    }
+}


### PR DESCRIPTION
see PHPOffice/PHPExcel#51

to test installation with [composer](http://getcomposer.org): 

add this to your composer.json config file

``` json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/csanquer/PHPExcel.git"
        }
    ],
    "minimum-stability": "dev",
    "require": {
        "phpoffice/phpexcel": "*"
    }
}
```

then run 

``` sh
php composer.phar update
```

A class mapping is generated in `vendor/composer/autoload_classmap.php` and you need only to include the autoloader `vendor/autoload.php`
