### PR TITLE
made dataTypeForValue (practically) overwritable

### DIFF
--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -60,7 +60,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
 		}
 
 		// Set value explicit
-		$cell->setValueExplicit( $value, self::dataTypeForValue($value) );
+		$cell->setValueExplicit( $value, $this->dataTypeForValue($value) );
 
 		// Done!
 		return true;


### PR DESCRIPTION
PHPExcel_Cell_DefaultValueBinder::bindValue() called dataTypeForValue() in self:: scope.
This made it impossible to overwrite dataTypeForValue() without overwrting bindValue().
Now calling dataTypeForValue() via $this.
