### PR TITLE
Change use of is_a() to use instanceof

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -1513,7 +1513,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 	public function duplicateConditionalStyle(array $pCellStyle = null, $pRange = '')
 	{
 		foreach($pCellStyle as $cellStyle) {
-			if (!is_a($cellStyle,'PHPExcel_Style_Conditional')) {
+			if (!($cellStyle instanceof PHPExcel_Style_Conditional)) {
 				throw new Exception('Style is not a conditional style');
 			}
 		}


### PR DESCRIPTION
While is_a() is no longer deprecated, there are bound to be some people using PHP versions that still have it marked as deprecated.
This is the only occurrence of is_a in the whole of PHPExcel; everywhere else it's using instanceof, so I figured it would be sensible to make it consistent.
