### PR TITLE
Fix to cellExists for non-existent namedRanges

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -1203,6 +1203,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 					}
 				}
 			}
+			else { return false; }
 		}
 
 		// Uppercase coordinate


### PR DESCRIPTION
Found an issue where cellExists was failing on a non-existent namedRange
as it was flowing down to the coordinateFromString (1217) call.  Proposed
change trusts the REGEXP check and if $namedRange == NULL after all
then simply return false (ie the cell does not exist).
