### PR TITLE
Use mkdtemp in PHPExcel_Shared_ZipArchive to avoid race condition

### DIFF
--- a/Classes/PHPExcel/Shared/File.php
+++ b/Classes/PHPExcel/Shared/File.php
@@ -136,4 +136,24 @@ class PHPExcel_Shared_File
 		return realpath(sys_get_temp_dir());
 	}
 
+	/**
+	 * Create a unique temporary directory.
+	 *
+	 * @return string
+	 */
+	public static function mkdtemp($prefix)
+	{
+		$tempname = tempnam(PHPExcel_Shared_File::sys_get_temp_dir(), $prefix);
+
+		if (file_exists($tempname)) {
+			unlink($tempname);
+		}
+
+		$ret = mkdir($tempname, 0700);
+		if (!$ret) {
+			throw new Exception("Error creating directory: " . $tempname);
+		}
+
+		return $tempname;
+	}
 }

--- a/Classes/PHPExcel/Shared/ZipArchive.php
+++ b/Classes/PHPExcel/Shared/ZipArchive.php
@@ -26,7 +26,7 @@
  */
 
 if (!defined('PCLZIP_TEMPORARY_DIR')) {
-	define('PCLZIP_TEMPORARY_DIR', PHPExcel_Shared_File::sys_get_temp_dir());
+	define('PCLZIP_TEMPORARY_DIR', PHPExcel_Shared_File::sys_get_temp_dir() . '/');
 }
 require_once PHPEXCEL_ROOT . 'PHPExcel/Shared/PCLZip/pclzip.lib.php';
 
@@ -69,7 +69,7 @@ class PHPExcel_Shared_ZipArchive
      */
 	public function open($fileName)
 	{
-		$this->_tempDir = PHPExcel_Shared_File::sys_get_temp_dir();
+		$this->_tempDir = PHPExcel_Shared_File::mkdtemp('PHPExcel_Shared_ZipArchive');
 
 		$this->_zip = new PclZip($fileName);
 
@@ -83,6 +83,7 @@ class PHPExcel_Shared_ZipArchive
      */
 	public function close()
 	{
+		rmdir($this->_tempDir);
 	}
 
 


### PR DESCRIPTION
When use Excel2007 writer with PHPExcel_Settings::PCLZIP files with same name placed in one temporary directory. Two parallel scripts can interfere with each other.
