### PR TITLE
Fix character encoding issue when saving for csv

### DIFF
--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -383,7 +383,7 @@ class PHPExcel_Shared_String
 	public static function SanitizeUTF8($value)
 	{
 		if (self::getIsIconvEnabled()) {
-			$value = @iconv('UTF-8', 'UTF-8', $value);
+			$value = @iconv(mb_internal_encoding(), 'UTF-8', $value);
 			return $value;
 		}
 


### PR DESCRIPTION
The existing code assumes by default that the encoding is 'UTF-8', causes a bug when trying to parse inputs from CSV for the character ü, in the word für.

Say my machine's input is ISO-8851, then iconv would have suppressed and truncate the string as 'ü' is not a valid charset of 'UTF-8'.
