### PR TITLE
Remove BOM

### DIFF
--- a/Classes/PHPExcel/Calculation/MathTrig.php
+++ b/Classes/PHPExcel/Calculation/MathTrig.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * PHPExcel
  *

--- a/Classes/PHPExcel/locale/cs/config
+++ b/Classes/PHPExcel/locale/cs/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/cs/functions
+++ b/Classes/PHPExcel/locale/cs/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/da/config
+++ b/Classes/PHPExcel/locale/da/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/da/functions
+++ b/Classes/PHPExcel/locale/da/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/de/config
+++ b/Classes/PHPExcel/locale/de/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/de/functions
+++ b/Classes/PHPExcel/locale/de/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/en/uk/config
+++ b/Classes/PHPExcel/locale/en/uk/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/es/config
+++ b/Classes/PHPExcel/locale/es/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/es/functions
+++ b/Classes/PHPExcel/locale/es/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/fi/config
+++ b/Classes/PHPExcel/locale/fi/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/fi/functions
+++ b/Classes/PHPExcel/locale/fi/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/fr/config
+++ b/Classes/PHPExcel/locale/fr/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/fr/functions
+++ b/Classes/PHPExcel/locale/fr/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/hu/config
+++ b/Classes/PHPExcel/locale/hu/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/hu/functions
+++ b/Classes/PHPExcel/locale/hu/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/it/config
+++ b/Classes/PHPExcel/locale/it/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/it/functions
+++ b/Classes/PHPExcel/locale/it/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/nl/config
+++ b/Classes/PHPExcel/locale/nl/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/nl/functions
+++ b/Classes/PHPExcel/locale/nl/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/no/config
+++ b/Classes/PHPExcel/locale/no/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/no/functions
+++ b/Classes/PHPExcel/locale/no/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/pl/config
+++ b/Classes/PHPExcel/locale/pl/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/pl/functions
+++ b/Classes/PHPExcel/locale/pl/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/pt/br/config
+++ b/Classes/PHPExcel/locale/pt/br/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/pt/br/functions
+++ b/Classes/PHPExcel/locale/pt/br/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ##	Add-in and Automation functions			Funções Suplemento e Automação
 ##
 GETPIVOTDATA		= INFODADOSTABELADINÂMICA	##	Retorna os dados armazenados em um relatório de tabela dinâmica

--- a/Classes/PHPExcel/locale/pt/config
+++ b/Classes/PHPExcel/locale/pt/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/pt/functions
+++ b/Classes/PHPExcel/locale/pt/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ##	Add-in and Automation functions			Funções de Suplemento e Automatização
 ##
 GETPIVOTDATA		= OBTERDADOSDIN			##	Devolve dados armazenados num relatório de Tabela Dinâmica

--- a/Classes/PHPExcel/locale/ru/config
+++ b/Classes/PHPExcel/locale/ru/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/ru/functions
+++ b/Classes/PHPExcel/locale/ru/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/sv/config
+++ b/Classes/PHPExcel/locale/sv/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/sv/functions
+++ b/Classes/PHPExcel/locale/sv/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ##	Add-in and Automation functions			Tilläggs- och automatiseringsfunktioner
 ##
 GETPIVOTDATA		= HÄMTA.PIVOTDATA		##	Returnerar data som lagrats i en pivottabellrapport

--- a/Classes/PHPExcel/locale/tr/config
+++ b/Classes/PHPExcel/locale/tr/config
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel

--- a/Classes/PHPExcel/locale/tr/functions
+++ b/Classes/PHPExcel/locale/tr/functions
@@ -1,4 +1,4 @@
-﻿##
+##
 ## PHPExcel
 ##
 ## Copyright (c) 2006 - 2011 PHPExcel


### PR DESCRIPTION
[Byte-Order-Mark](http://en.wikipedia.org/wiki/Byte_order_mark) has to be always avoided.
It can leads to a lot of misbehaviours with headers sent to the client.

This PR converts the files to UTF8 Without BOM.

Indeed the test:

```
EngineeringTest::testBESSELI with data set #1 (-1, 6, 2.2488660949282E-5)
```

Was affected by BOMs, and now it passes.
