### PR TITLE
Use appropriate dereferencing

### DIFF
--- a/Classes/PHPExcel/Worksheet/AutoFilter.php
+++ b/Classes/PHPExcel/Worksheet/AutoFilter.php
@@ -826,20 +826,20 @@ class PHPExcel_Worksheet_AutoFilter
 			if (is_object($value)) {
 				if ($key == '_workSheet') {
 					//	Detach from worksheet
-					$this->$key = NULL;
+					$this->{$key} = NULL;
 				} else {
-					$this->$key = clone $value;
+					$this->{$key} = clone $value;
 				}
 			} elseif ((is_array($value)) && ($key == '_columns')) {
 				//	The columns array of PHPExcel_Worksheet_AutoFilter objects
-				$this->$key = array();
+				$this->{$key} = array();
 				foreach ($value as $k => $v) {
-					$this->$key[$k] = clone $v;
+					$this->{$key}[$k] = clone $v;
 					// attach the new cloned Column to this new cloned Autofilter object
-					$this->$key[$k]->setParent($this);
+					$this->{$key}[$k]->setParent($this);
 				}
 			} else {
-				$this->$key = $value;
+				$this->{$key} = $value;
 			}
 		}
 	}


### PR DESCRIPTION
Array reference has the priority over key reference.

``` php
$this->$key[$k] = 1;
// Is equal to
$key = $key[$k];
$this->$key = 1;
```

If you want to get the double dynamic reference, you need to use the Curly brackets.

``` php
$this->{$key}[$k] = 1;
```

So now this test does not get errors anymore:

```
1) AutoFilterTest::testClone
Illegal string offset 'L'

/var/www/tmp/PHPExcel/Classes/PHPExcel/Worksheet/AutoFilter.php:837
/var/www/tmp/PHPExcel/unitTests/Classes/PHPExcel/Worksheet/AutoFilterTest.php:330
```
