### PR TITLE
Tests: explicit locale to en_US.utf8

### DIFF
--- a/unitTests/bootstrap.php
+++ b/unitTests/bootstrap.php
@@ -10,6 +10,8 @@
 
 chdir(dirname(__FILE__));
 
+setlocale(LC_ALL, 'en_US.utf8');
+
 // PHP 5.3 Compat
 date_default_timezone_set('Europe/London');
 


### PR DESCRIPTION
A bunch of tests use `localeconv` to detect locale and expect results.
In order to work correctly on all systems, tests must explicitly set it.

If `en_US.utf8` is not present in `locale -a`, no change is made, so there is no break.

This PR resolves those tests:

```

) TextDataTest::testDOLLAR with data set #0 (123.456, 2, '$123.46')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'$123.46'
+'123.46'

/var/www/tmp/PHPExcel/unitTests/Classes/PHPExcel/Calculation/TextDataTest.php:282

) TextDataTest::testDOLLAR with data set #1 (123.321, 2, '$123.32')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'$123.32'
+'123.32'

/var/www/tmp/PHPExcel/unitTests/Classes/PHPExcel/Calculation/TextDataTest.php:282

) TextDataTest::testDOLLAR with data set #2 (1234567, -3, '$1,235,000')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'$1,235,000'
+'1235000'

/var/www/tmp/PHPExcel/unitTests/Classes/PHPExcel/Calculation/TextDataTest.php:282

) TextDataTest::testDOLLAR with data set #3 (1234567, -5, '$1,200,000')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'$1,200,000'
+'1200000'

/var/www/tmp/PHPExcel/unitTests/Classes/PHPExcel/Calculation/TextDataTest.php:282
```
