### PR TITLE
change self to static to allow value binder to be extended

### DIFF
--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -60,7 +60,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
         }
 
         // Set value explicit
-        $cell->setValueExplicit( $value, self::dataTypeForValue($value) );
+        $cell->setValueExplicit( $value, static::dataTypeForValue($value) );
 
         // Done!
         return TRUE;


### PR DESCRIPTION
When setting a custom valuebinder object that extends DefaultValueBinder and only implements dataTypeForValue() the method does not get called due to the use of self:: in bindValue() as self refers to the DefaultvaluBinder class. Ofcourse the custom binder could implement that method as well, but i think it makes more sense to use static:: to make the code DRY