### PR TITLE
CountCharacters code doesn't match the comments

### DIFF
--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -548,12 +548,13 @@ class PHPExcel_Shared_String
 	 */
 	public static function CountCharacters($value, $enc = 'UTF-8')
 	{
-		if (self::getIsIconvEnabled()) {
-			return iconv_strlen($value, $enc);
-		}
-
+      
 		if (self::getIsMbstringEnabled()) {
 			return mb_strlen($value, $enc);
+		}
+
+		if (self::getIsIconvEnabled()) {
+			return iconv_strlen($value, $enc);
 		}
 
 		// else strlen


### PR DESCRIPTION
Changed so that the code matches the comments by switching mb_strlen and iconv_strlen.

iconv_strlen fails more often then mb_strlen on utf8 strings. These failures give these kind of errors:
function.iconv-strlen: Detected an illegal character in input string
