### PR TITLE
Fatal Error on non object in Worksheet.php

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -378,9 +378,10 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
      */
     public function disconnectCells()
     {
-        $this->_cellCollection->unsetWorksheetCells();
-        $this->_cellCollection = NULL;
-
+    	if ( $this->_cellCollection != null ){
+            $this->_cellCollection->unsetWorksheetCells();
+            $this->_cellCollection = NULL;
+    	}
         //    detach ourself from the workbook, so that it can then delete this worksheet successfully
         $this->_parent = null;
     }


### PR DESCRIPTION
the disconnectCells method is not always fully initialized with the attribute 
_cellCollection, so a check needs to be done. Otherwise a fatal error occurs.
happens if multiple xsl are created from csv file
