### PR TITLE
Fix merged-cell borders on HTML/PDF output

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -1231,15 +1231,8 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 					$rowSpan = $spans['rowspan'];
 					$colSpan = $spans['colspan'];
 					//Also apply style from last cell in merge to fix borders - relies on !important for non-none border declarations in _createCSSStyleBorder
-					if($colSpan>1) {
-						$endCellCoord = PHPExcel_Cell::stringFromColumnIndex($colNum+$colSpan-1) . ($pRow + 1);
-						$cssClass .= ' style' . $pSheet->getCell($endCellCoord)->getXfIndex();	
-					}
-					
-					if($rowSpan>1) {
-						$endCellCoord = PHPExcel_Cell::stringFromColumnIndex($colNum) . ($pRow + $rowSpan);
-						$cssClass .= ' style' . $pSheet->getCell($endCellCoord)->getXfIndex();	
-					}
+					$endCellCoord = PHPExcel_Cell::stringFromColumnIndex($colNum + $colSpan - 1) . ($pRow + $rowSpan);
+					$cssClass .= ' style' . $pSheet->getCell($endCellCoord)->getXfIndex();	
 				}
 
 				// Write


### PR DESCRIPTION
HTML Writer will colspan/rowspan merged cells from the base cell but only apply the base cell's formatting.  As a result, borders that are applied to right/bottom edges of merged blocks are being ignored.

Not the most elegant approach but is functional and performant.  Essentially force all non-none borders to be !important css attributes, then apply both base Cell and last Cell styleXf Classes to the base cell.  The !importants will override the base cell none borders for right and bottom.

Alternative approach I guess would be to check for merged cells during class generation and use getBottom() and getRight() calls against the last cell rather than the base cell.  I had attempted this a few months ago but dropped it due to poor performance.
