### PR TITLE
Fix: Hyperlinks break when removing rows

### DIFF
--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -274,7 +274,7 @@ class PHPExcel_ReferenceHelper
 		$pSheet->setComments($aNewComments); // replace the comments array
 
 		// Update worksheet: hyperlinks
-		$aHyperlinkCollection = array_reverse($pSheet->getHyperlinkCollection(), true);
+		$aHyperlinkCollection = $pNumCols > 0 || $pNumRows > 0 ? array_reverse($pSheet->getHyperlinkCollection(), true) : $pSheet->getHyperlinkCollection();
 		foreach ($aHyperlinkCollection as $key => $value) {
 			$newReference = $this->updateCellReference($key, $pBefore, $pNumCols, $pNumRows);
 			if ($key != $newReference) {


### PR DESCRIPTION
When removing a row from above cells with hyperlinks, HyperlinkCollection gets broken due to the reversed order of operation. The reversing of array (in current code) works as expected only when inserting rows ($pNumRows/Cols is positive), but breaks when removing rows ($pNumRows/Cols is negative). Therefore, reversing should be conditional. Not sure if this is the best solution, but it works. The same should most likely apply for other reference alteration codes in this file where array_reverse (or reverse order of operation) is used.

![removing rows](https://f.cloud.github.com/assets/821784/313535/36784390-97b1-11e2-94d5-5a0460348918.jpg)
