### PR TITLE
Additions to PHPExcel_Chart_Layout to allow manual 3D rotations

### DIFF
--- a/Classes/PHPExcel/Chart/Layout.php
+++ b/Classes/PHPExcel/Chart/Layout.php
@@ -70,6 +70,41 @@ class PHPExcel_Chart_Layout
 	 */
 	private $_yPos		= NULL;
 
+    /**
+     * Enable manual 3D view settings for rotation and perspective
+     *
+     * @var boolean
+     */
+    private $_view3D    = false;
+
+    /**
+     * 3D X-Rotation
+     *
+     * @var float
+     */
+    private $_xRot		= 0;
+
+    /**
+     * 3D Y-Rotation
+     *
+     * @var float
+     */
+    private $_yRot		= 30;
+
+    /**
+     * Enable manual 3D view settings for rotation and perspective
+     *
+     * @var boolean
+     */
+    private $_rAngAx    = false;
+
+    /**
+     * 3D Perspective
+     *
+     * @var float
+     */
+    private $_perspective   = 30;
+
 	/**
 	 * width
 	 *
@@ -243,6 +278,104 @@ class PHPExcel_Chart_Layout
 	public function setYPosition($value) {
 		$this->_yPos = $value;
 	}
+
+    /**
+     * Get manual 3D view setting (enabled or disabled)
+     *
+     * @return boolean
+     */
+    public function getManual3dAlign() {
+        return $this->_view3D;
+    }
+
+    /**
+     * Enable/disable manual 3D view settings for rotation and perspective
+     *
+     * @param Manual 3D Alignmnet $value
+     */
+    public function setManual3dAlign($value) {
+        $this->_view3D = $value;
+    }
+
+    /**
+     * Get 3D X-Rotation
+     *
+     * @return float
+     */
+    public function getXRotation()
+    {
+        return $this->_xRot;
+    }
+
+    /**
+     * Set 3D X-Rotation
+     *
+     * @param float $value
+     */
+    public function setXRotation($value)
+    {
+        $this->_xRot = $value;
+    }
+
+    /**
+     * Get 3D Y-Rotation
+     *
+     * @return float
+     */
+    public function getYRotation()
+    {
+        return $this->_yRot;
+    }
+
+    /**
+     * Set 3D Y-Rotation
+     *
+     * @param float $value
+     */
+    public function setYRotation($value)
+    {
+        $this->_yRot = $value;
+    }
+
+    /**
+     * Get right angle axes setting
+     *
+     * @return boolean
+     */
+    public function getRightAngleAxes()
+    {
+        return $this->_rAngAx;
+    }
+
+    /**
+     * Set right angle axes setting
+     *
+     * @param boolean $value
+     */
+    public function setRightAngleAxes($value)
+    {
+        $this->_rAngAx = $value;
+    }
+
+    /**
+     * Get 3D Perspective
+     *
+     * @return float
+     */
+    public function getPerspective()
+    {
+        return $this->_perspective;
+    }
+
+    /**
+     * Set 3D Perspective
+     *
+     * @param float $value
+     */
+    public function setPerspective($value)
+    {
+        $this->_perspective = $value;
+    }
 
 	/**
 	 * Get Width

--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -229,11 +229,30 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
 			return;
 		}
 
+        $layout = $plotArea->getLayout();
+
+        if(!is_null($layout) &&
+            $layout->getManual3dAlign()) {
+
+            $objWriter->startElement('c:view3D');
+                $objWriter->startElement('c:rotX');
+                    $objWriter->writeAttribute('val', $layout->getXRotation());
+                $objWriter->endElement();
+                $objWriter->startElement('c:rotY');
+                    $objWriter->writeAttribute('val', $layout->getYRotation());
+                $objWriter->endElement();
+                $objWriter->startElement('c:rAngAx');
+                    $objWriter->writeAttribute('val', ($layout->getRightAngleAxes() ? '1' : '0'));
+                $objWriter->endElement();
+                $objWriter->startElement('c:perspective');
+                    $objWriter->writeAttribute('val', $layout->getPerspective());
+                $objWriter->endElement();
+            $objWriter->endElement();
+        }
+
 		$id1 = $id2 = 0;
 		$this->_seriesIndex = 0;
 		$objWriter->startElement('c:plotArea');
-
-			$layout = $plotArea->getLayout();
 
 			$this->_writeLayout($layout, $objWriter);
 


### PR DESCRIPTION
Today I made additions that allow manual rotations of a 3D chart, such as a pie chart. These may not be included in exactly the correct places, but they are useful for me as-is.

Using a layout sample like this...

```
$layoutPlotArea = new PHPExcel_Chart_Layout();
$layoutPlotArea->setManual3dAlign(true);
$layoutPlotArea->setXRotation(50);
$layoutPlotArea->setYRotation(0);
$layoutPlotArea->setPerspective(15);
$plotArea = new PHPExcel_Chart_PlotArea($layoutPlotArea, array($series1));
```

Results in XML additions of,,,

```
<c:view3D>
    <c:rotX val="50"/>
    <c:rotY val="0"/>
    <c:rAngAx val="0"/>
    <c:perspective val="15"/>
</c:view3D>
```
