### PR TITLE
Fatal Error Excel File loaded as OOCalc

### DIFF
--- a/Classes/PHPExcel/Reader/OOCalc.php
+++ b/Classes/PHPExcel/Reader/OOCalc.php
@@ -338,6 +338,9 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 
 //		echo '<h1>Meta Information</h1>';
 		$xml = simplexml_load_string($zip->getFromName("meta.xml"));
+//Fatal Error is generates if you accidentally load a xls file 
+//but select PHPExcel_IOFactory::CreateReader("OOcalc")
+if (is_object($xml) {
 		$namespacesMeta = $xml->getNamespaces(true);
 //		echo '<pre>';
 //		print_r($namespacesMeta);
@@ -677,6 +680,8 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 				}
 				++$worksheetID;
 			}
+// return here
+}
 		}
 
 		// Return


### PR DESCRIPTION
Fatal Error is generates if you accidentally load a xls file 
but select PHPExcel_IOFactory::CreateReader("OOcalc"),
Fatal error: Call to a member function getNamespaces() on a non-object in .../Classes/PHPExcel/Reader/OOCalc.php on line...
