### PR TITLE
Fix performance issue when exporting from Excel 2007 to CSV due to empty formatted columns in source and readDataOnly option is deactivated.

### DIFF
--- a/Classes/PHPExcel/Writer/CSV.php
+++ b/Classes/PHPExcel/Writer/CSV.php
@@ -124,8 +124,8 @@ class PHPExcel_Writer_CSV extends PHPExcel_Writer_Abstract implements PHPExcel_W
 		}
 
 		//	Identify the range that we need to extract from the worksheet
-		$maxCol = $sheet->getHighestColumn();
-		$maxRow = $sheet->getHighestRow();
+		$maxCol = $sheet->getHighestDataColumn();
+		$maxRow = $sheet->getHighestDataRow();
 
 		// Write rows to file
 		for($row = 1; $row <= $maxRow; ++$row) {
@@ -135,7 +135,7 @@ class PHPExcel_Writer_CSV extends PHPExcel_Writer_Abstract implements PHPExcel_W
 			$this->_writeLine($fileHandle, $cellsArray[0]);
 		}
 
-		// Close file
+		// Close files
 		fclose($fileHandle);
 
 		PHPExcel_Calculation::setArrayReturnType($saveArrayReturnType);


### PR DESCRIPTION
When exporting from Excel 2007 to CSV, some Excel files define a big list of columns in it's file worksheet. If the ReadDataOnly is deactivated, the export is extremely slow and the CSV is as big as the column definition, even though there is no data in those columns. Most of the samples where I observer this behavior has more than 14000 columns defined, but only a few dozens of columns have data.

After reviewing the code, I found that the cause of this problem is that the Excel2007 Reader iterates over all the columns to add styling information like Visible, Collapsed, OutlineLevel, Width, etc. and adds that information to the Worksheet, increasing _cachedHighestColumn variable. CSV Writer class uses that value to iterate results and causes the problem.

To reproduce, here is a test case:
http://pastebin.com/W5cUD6QC

I don't have a file to reproduce it as all xlsx files have contact information that I can't post without permission and I do not own Excel to generate the same type of file. Using OpenOpeffice i'm not able to generate a similar file.

A proposed solution is to use getHighestDataColumn instead of getHighestColumn when iterating values in the Writer classes.
