### PR TITLE
Update Excel2007 writer to use getDiskCachingDirectory().

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007.php
+++ b/Classes/PHPExcel/Writer/Excel2007.php
@@ -181,7 +181,7 @@ class PHPExcel_Writer_Excel2007 extends PHPExcel_Writer_Abstract implements PHPE
 			// If $pFilename is php://output or php://stdout, make it a temporary file...
 			$originalFilename = $pFilename;
 			if (strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout') {
-				$pFilename = @tempnam(PHPExcel_Shared_File::sys_get_temp_dir(), 'phpxltmp');
+				$pFilename = @tempnam($this->getDiskCachingDirectory(), 'phpxltmp');
 				if ($pFilename == '') {
 					$pFilename = $originalFilename;
 				}


### PR DESCRIPTION
The Excel2007 writer was using the system's temp directory, which fails on systems where it is inaccessible.
