### PR TITLE
add read pivot table for excel2007

### DIFF
--- a/Classes/PHPExcel/PivotTable.php
+++ b/Classes/PHPExcel/PivotTable.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * PHPExcel
+ *
+ * Copyright (c) 2006 - 2013 PHPExcel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @license		http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
+ * @version		##VERSION##, ##DATE##
+ */
+
+/**
+ * PHPExcel_PivotTable
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ */
+class PHPExcel_PivotTable
+{
+  /**
+	 * PivotTable target
+	 *
+	 * @var string
+	 */
+	private $_target = '';
+  
+  /**
+	 * PivotTable name
+	 *
+	 * @var string
+	 */
+	private $_name = '';
+  
+  /**
+	 * PivotTable id
+	 *
+	 * @var string
+	 */
+	private $_id = '';
+  
+  /**
+	 * PivotTable data
+	 *
+	 * @var string
+	 */
+	private $_data = '';
+  
+  /**
+	 * Collection of PivotCacheDefinition
+	 *
+	 * @var string
+	 */
+	private $_pivotCacheDefinitionCollection = array();
+
+	/**
+	 * Worksheet
+	 *
+	 * @var PHPExcel_Worksheet
+	 */
+	private $_worksheet = null;
+  
+  /**
+	 * Create a new PHPExcel_PivotTable
+	 */
+  public function __construct($id,$target,$xmlData)
+	{
+    $this->setId($id);
+    $this->setTarget($target);
+    // patch to correct  dxfId="XX"
+    $this->_data = preg_replace("/ dxfId=\"..\"/i","",$xmlData);
+  }
+  
+  public function setId($id){       
+    $this->_id = preg_replace("/^rId/i","",$id);
+  }
+  
+  public function getId(){
+    return $this->_id;
+  }
+  
+  public function getName(){
+    return $this->_name;
+  }
+  
+  public function getTarget(){
+    return $this->_target;
+  }
+  
+  public function setTarget($target){
+    $this->_target = $target;
+    $this->_name = basename($target);
+  }
+  
+  public function addPivotCacheDefinition(PHPExcel_PivotTable_PivotCacheDefinition $PivotCacheDefinition){
+   $this->_pivotCacheDefinitionCollection[] = $PivotCacheDefinition;
+  }
+  
+  public function getXmlData(){
+    return $this->_data;
+  }
+  
+  /**
+	 * Set Worksheet
+	 *
+	 * @param	PHPExcel_Worksheet	$pValue
+	 * @throws	PHPExcel_PivotTable_Exception
+	 * @return PHPExcel_PivotTable
+	 */
+	public function setWorksheet(PHPExcel_Worksheet $pValue = null) {
+		$this->_worksheet = $pValue;
+
+		return $this;
+	}
+  
+  public function getPivotCacheDefinitionCollection(){
+    return $this->_pivotCacheDefinitionCollection ;
+  }
+  
+  public static function normalizePath($path)
+  {
+      $parts = array();// Array to build a new path from the good parts
+      $path = str_replace('\\', '/', $path);// Replace backslashes with forwardslashes
+      $path = preg_replace('/\/+/', '/', $path);// Combine multiple slashes into a single slash
+      $segments = explode('/', $path);// Collect path segments
+      $test = '';// Initialize testing variable
+      foreach($segments as $segment)
+      {
+          if($segment != '.')
+          {
+              $test = array_pop($parts);
+              if(is_null($test))
+                  $parts[] = $segment;
+              else if($segment == '..')
+              {
+                  if($test == '..')
+                      $parts[] = $test;
+  
+                  if($test == '..' || $test == '')
+                      $parts[] = $segment;
+              }
+              else
+              {
+                  $parts[] = $test;
+                  $parts[] = $segment;
+              }
+          }
+      }
+      return implode('/', $parts);
+  }
+}

--- a/Classes/PHPExcel/PivotTable/PivotCacheDefinition.php
+++ b/Classes/PHPExcel/PivotTable/PivotCacheDefinition.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * PHPExcel
+ *
+ * Copyright (c) 2006 - 2013 PHPExcel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @license		http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
+ * @version		##VERSION##, ##DATE##
+ */
+
+/**
+ * PHPExcel_PivotTable
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ */
+class PHPExcel_PivotTable_PivotCacheDefinition
+{
+  /**
+	 * PivotCacheDefinition target
+	 *
+	 * @var string
+	 */
+	private $_target = '';
+  
+  /**
+	 * PivotCacheDefinition name
+	 *
+	 * @var string
+	 */
+	private $_name = '';
+  
+  /**
+	 * PivotCacheDefinition id
+	 *
+	 * @var string
+	 */
+	private $_id = '';
+  
+  /**
+	 * PivotCacheDefinition data
+	 *
+	 * @var string
+	 */
+	private $_data = '';
+  
+  /**
+	 * Collection of PivotCacheRecords
+	 *
+	 * @var string
+	 */
+	private $_pivotCacheRecordsCollection = array();
+
+	/**
+	 * PivotTable
+	 *
+	 * @var PHPExcel_PivotTable
+	 */
+	private $_pivotTable = null;
+  
+    /**
+	 * Create a new PHPExcel_PivotTable_PivotCacheDefinition
+	 */
+  public function __construct($id,$target,$xmlData)
+	{
+    $this->setId($id);
+    $this->setTarget($target);
+    $this->_data = $xmlData;
+  }
+  
+  public function getName(){
+    return $this->_name;
+  }
+  
+  public function getTarget(){
+    return $this->_target;
+  }
+  
+  public function getId(){
+    return $this->_id;
+  }
+  
+  public function setId($id){       
+    $this->_id = preg_replace("/^rId/i","",$id);
+  }
+  
+  public function setTarget($target){
+    $this->_target = $target;
+    $this->_name = basename($target);
+  }
+  
+  public function getXmlData(){
+    return $this->_data;
+  }
+  
+  public function addPivotCacheRecords(PHPExcel_PivotTable_PivotCacheDefinition_PivotCacheRecords $PivotCacheRecords){
+   $this->_pivotCacheRecordsCollection[] = $PivotCacheRecords;
+  }
+  
+  public function getPivotCacheRecordsCollection(){
+    return $this->_pivotCacheRecordsCollection;
+  }
+  
+}

--- a/Classes/PHPExcel/PivotTable/PivotCacheDefinition/PivotCacheRecords.php
+++ b/Classes/PHPExcel/PivotTable/PivotCacheDefinition/PivotCacheRecords.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHPExcel
+ *
+ * Copyright (c) 2006 - 2013 PHPExcel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @license		http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
+ * @version		##VERSION##, ##DATE##
+ */
+
+/**
+ * PHPExcel_PivotTable
+ *
+ * @category	PHPExcel
+ * @package		PHPExcel_Reader_Excel2007
+ * @copyright	Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+ */
+class PHPExcel_PivotTable_PivotCacheDefinition_PivotCacheRecords
+{
+  /**
+	 * PivotCacheRecords target
+	 *
+	 * @var string
+	 */
+	private $_target = '';
+  
+  /**
+	 * PivotCacheRecords name
+	 *
+	 * @var string
+	 */
+	private $_name = '';
+  
+  /**
+	 * PivotCacheRecords id
+	 *
+	 * @var string
+	 */
+	private $_id = '';
+  
+  /**
+	 * PivotCacheRecords data
+	 *
+	 * @var string
+	 */
+	private $_data = '';
+
+	/**
+	 * PivotCacheDefinition
+	 *
+	 * @var PHPExcel_PivotTable_PivotCacheDefinition
+	 */
+	private $_pivotCacheDefinition = null;
+  
+  public function __construct($id,$target,$xmlData)
+	{
+    $this->setId($id);
+    $this->setTarget($target);
+    $this->_data = $xmlData;
+  }
+  
+  public function getName(){
+    return $this->_name;
+  }
+  
+  public function getTarget(){
+    return $this->_target;
+  }
+  
+  public function setTarget($target){
+    $this->_target = $target;
+    $this->_name = basename($target);
+  }
+  
+  public function getId(){
+    return $this->_id;
+  }
+  
+  public function setId($id){       
+    $this->_id = preg_replace("/^rId/i","",$id);
+  }
+  
+  public function getXmlData(){
+    return $this->_data;
+  }   
+}

--- a/Classes/PHPExcel/Reader/Abstract.php
+++ b/Classes/PHPExcel/Reader/Abstract.php
@@ -50,7 +50,15 @@ abstract class PHPExcel_Reader_Abstract implements PHPExcel_Reader_IReader
 	 *
 	 * @var	boolean
 	 */
-	protected $_includeCharts = FALSE;
+	protected $_includeCharts = FALSE;    
+  
+  /**
+	 * Read Pivottable that are defined in the workbook?
+	 * Identifies whether the Reader should read the definitions for any Pivottable that exist in the workbook;
+	 *
+	 * @var	boolean
+	 */
+	protected $_includePivotTable = FALSE;   
 
 	/**
 	 * Restrict which sheets should be loaded?
@@ -121,6 +129,33 @@ abstract class PHPExcel_Reader_Abstract implements PHPExcel_Reader_IReader
 		$this->_includeCharts = (boolean) $pValue;
 		return $this;
 	}
+  
+  /**
+	 * Read Pivottable in workbook?
+	 *		If this is true, then the Reader will include any Pivottable that exist in the workbook.
+	 *      Note that a ReadDataOnly value of false overrides, and Pivottable won't be read regardless of the IncludePivottable value.
+	 *		If false (the default) it will ignore any Pivottable defined in the workbook file.
+	 *
+	 * @return	boolean
+	 */
+	public function getIncludePivotTable() {
+		return $this->_includePivotTable;
+	}    
+  
+  	/**
+	 * Set read Pivottable in workbook
+	 *		Set to true, to advise the Reader to include any Pivottable that exist in the workbook.
+	 *      Note that a ReadDataOnly value of false overrides, and Pivottable won't be read regardless of the IncludePivottable value.
+	 *		Set to false (the default) to discard Pivottable.
+	 *
+	 * @param	boolean	$pValue
+	 *
+	 * @return	PHPExcel_Reader_IReader
+	 */
+	public function setIncludePivotTable($pValue = FALSE) {
+		$this->_includePivotTable = (boolean) $pValue;
+		return $this;
+	}    
 
 	/**
 	 * Get which sheets to load

--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -107,6 +107,13 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
      * @var PHPExcel_Chart[]
      */
     private $_chartCollection = array();
+    
+    /**
+     * Collection of PivotTable objects
+     *
+     * @var PHPExcel_PivotTable[]
+     */
+    private $_pivotTableCollection = array();
 
     /**
      * Worksheet title
@@ -616,6 +623,36 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
             }
         }
         return false;
+    }
+    
+    /**
+     * Get collection of PivotTable
+     *
+     * @return PHPExcel_PivotTable[]
+     */
+    public function getPivotTableCollection()
+    {
+        return $this->_pivotTableCollection;
+    }
+    
+    /**
+     * Add PivotTable
+     *
+     * @param PHPExcel_PivotTable $pPivotTable
+     * @param int|null $iPivotTableIndex Index where PivotTable should go (0,1,..., or null for last)
+     * @return PHPExcel_PivotTable
+     */
+    public function addPivotTable(PHPExcel_PivotTable $pPivotTable = null, $iPivotTableIndex = null)
+    {
+        $pPivotTable->setWorksheet($this);
+        if (is_null($iPivotTableIndex)) {
+            $this->_pivotTableCollection[] = $pPivotTable;
+        } else {
+            // Insert the chart at the requested index
+            array_splice($this->_pivotTableCollection, $iPivotTableIndex, 0, array($pPivotTable));
+        }
+
+        return $pPivotTable;
     }
 
     /**

--- a/Classes/PHPExcel/Worksheet/RowDimension.php
+++ b/Classes/PHPExcel/Worksheet/RowDimension.php
@@ -85,6 +85,8 @@ class PHPExcel_Worksheet_RowDimension
 	 * @var int|null
 	 */
 	private $_xfIndex;
+  
+  private $_x14ac =null;
 
     /**
      * Create a new PHPExcel_Worksheet_RowDimension
@@ -98,6 +100,14 @@ class PHPExcel_Worksheet_RowDimension
 
 		// set row dimension as unformatted by default
 		$this->_xfIndex = null;
+    }
+    
+    public function setX14ac($x14ac){
+      $this->_x14ac = $x14ac;
+    }
+    
+    public function getX14ac(){
+      return $this->_x14ac;
     }
 
     /**

--- a/Classes/PHPExcel/Writer/Abstract.php
+++ b/Classes/PHPExcel/Writer/Abstract.php
@@ -42,6 +42,14 @@ abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
 	 * @var	boolean
 	 */
 	protected $_includeCharts = FALSE;
+  
+  /**
+	 * Read Pivottable that are defined in the workbook?
+	 * Identifies whether the Reader should read the definitions for any Pivottable that exist in the workbook;
+	 *
+	 * @var	boolean
+	 */
+	protected $_includePivotTable = FALSE;
 
 	/**
 	 * Pre-calculate formulas
@@ -87,6 +95,33 @@ abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
 	 */
 	public function setIncludeCharts($pValue = FALSE) {
 		$this->_includeCharts = (boolean) $pValue;
+		return $this;
+	}
+  
+  /**
+	 * Read Pivottable in workbook?
+	 *		If this is true, then the Reader will include any Pivottable that exist in the workbook.
+	 *      Note that a ReadDataOnly value of false overrides, and Pivottable won't be read regardless of the IncludePivottable value.
+	 *		If false (the default) it will ignore any Pivottable defined in the workbook file.
+	 *
+	 * @return	boolean
+	 */
+	public function getIncludePivotTable() {
+		return $this->_includePivotTable;
+	}
+  
+  /**
+	 * Set read Pivottable in workbook
+	 *		Set to true, to advise the Reader to include any Pivottable that exist in the workbook.
+	 *      Note that a ReadDataOnly value of false overrides, and Pivottable won't be read regardless of the IncludePivottable value.
+	 *		Set to false (the default) to discard Pivottable.
+	 *
+	 * @param	boolean	$pValue
+	 *
+	 * @return	PHPExcel_Reader_IReader
+	 */
+	public function setIncludePivotTable($pValue = FALSE) {
+		$this->_includePivotTable = (boolean) $pValue;
 		return $this;
 	}
 

--- a/Classes/PHPExcel/Writer/Excel2007/ContentTypes.php
+++ b/Classes/PHPExcel/Writer/Excel2007/ContentTypes.php
@@ -107,12 +107,52 @@ class PHPExcel_Writer_Excel2007_ContentTypes extends PHPExcel_Writer_Excel2007_W
 			}
 
 			// Worksheets
+      $relsPivotTable = array();
+      $relsPivotCache = array();
+      $relsPivotRecords = array();
 			$sheetCount = $pPHPExcel->getSheetCount();
 			for ($i = 0; $i < $sheetCount; ++$i) {
 				$this->_writeOverrideContentType(
 					$objWriter, '/xl/worksheets/sheet' . ($i + 1) . '.xml', 'application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml'
 				);
+        
+        $pivotTables =  $pPHPExcel->getSheet($i)->getPivotTableCollection();
+        if(count($pivotTables)>0){
+          foreach($pivotTables as $pivotTable){
+            $relsPivotTable[$pivotTable->getName()] = $pivotTable->getName();
+            $pivotCaches = $pivotTable->getPivotCacheDefinitionCollection();
+            foreach($pivotCaches as $pivotCache){
+              $relsPivotCache[$pivotCache->getName()] = $pivotCache->getName();
+              $pivotRecordsCol = $pivotCache->getPivotCacheRecordsCollection();
+              foreach($pivotRecordsCol as $pivotRecords){
+                $relsPivotRecords[$pivotRecords->getName()] = $pivotRecords->getName();
+              }
+            } 
+          }
+        }
 			}
+      
+      foreach($relsPivotCache as $key => $value){
+        $this->_writeOverrideContentType(
+				  $objWriter, 
+          '/xl/pivotCache/'.$value, 
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml'
+		  	);
+      }
+      foreach($relsPivotRecords as $key => $value){
+        $this->_writeOverrideContentType(
+				  $objWriter, 
+          '/xl/pivotCache/'.$value, 
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml'
+		  	);
+      }
+      foreach($relsPivotTable as $key => $value){
+        $this->_writeOverrideContentType(
+				  $objWriter, 
+          '/xl/pivotTables/'.$value, 
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml'
+		  	);
+      }
 
 			// Shared strings
 			$this->_writeOverrideContentType(

--- a/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
@@ -44,7 +44,7 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 	 * @return	string					XML Output
 	 * @throws	PHPExcel_Writer_Exception
 	 */
-	public function writeWorksheet($pSheet = null, $pStringTable = null, $includeCharts = FALSE)
+	public function writeWorksheet($pSheet = null, $pStringTable = null, $includeCharts = FALSE,$includePivotTable = FALSE)
 	{
 		if (!is_null($pSheet)) {
 			// Create XML writer
@@ -60,10 +60,16 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 
 			// Worksheet
 			$objWriter->startElement('worksheet');
-			$objWriter->writeAttribute('xml:space', 'preserve');
-			$objWriter->writeAttribute('xmlns', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+      if(!$includePivotTable){
+			  $objWriter->writeAttribute('xml:space', 'preserve');
+      }
+      $objWriter->writeAttribute('xmlns', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
 			$objWriter->writeAttribute('xmlns:r', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
-
+      if($includePivotTable){
+        $objWriter->writeAttribute('xmlns:mc', 'http://schemas.openxmlformats.org/markup-compatibility/2006'); 
+        $objWriter->writeAttribute('mc:Ignorable', 'x14ac');
+        $objWriter->writeAttribute('xmlns:x14ac', 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac');
+      }
 				// sheetPr
 				$this->_writeSheetPr($objWriter, $pSheet);
 
@@ -347,6 +353,10 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 				}
 			}
 			$objWriter->writeAttribute('outlineLevelCol',	(int)$outlineLevelCol);
+      
+      if($pSheet->getDefaultRowDimension()->getX14ac()){
+        $objWriter->writeAttribute('x14ac:dyDescent',	$pSheet->getDefaultRowDimension()->getX14ac());
+      }
 
 		$objWriter->endElement();
 	}
@@ -990,6 +1000,9 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 						$objWriter->startElement('row');
 						$objWriter->writeAttribute('r',	$currentRow);
 						$objWriter->writeAttribute('spans',	'1:' . $colCount);
+            if($rowDimension->getX14ac()){
+              $objWriter->writeAttribute('x14ac:dyDescent',	$rowDimension->getX14ac());
+            }
 
 						// Row dimensions
 						if ($rowDimension->getRowHeight() >= 0) {


### PR DESCRIPTION
add read pivot table for excel2007 in order to not loose it. Pivot Table
is not editable
exemple
$objReader = PHPExcel_IOFactory::createReader('CSV')->setDelimiter(';')
->setEnclosure('"')
->setLineEnding("\r\n")
->setSheetIndex(0);

$objPHPExcelFromCSV = $objReader->load("fichier/tmp.csv");
$sheet1 = $objPHPExcelFromCSV->getSheet(0);
$sheet1->setTitle('data');

$objReader = PHPExcel_IOFactory::createReader('Excel2007');
$objReader->setIncludePivotTable(true);
$objPHPExcel =$objReader->load("template/template_Q.xlsx");

if($objPHPExcel->getSheetByName("data")){
$objPHPExcel->removeSheetByIndex(
$objPHPExcel->getIndex(
$objPHPExcel->getSheetByName("data")
)
);
}

// $objPHPExcel->addSheet($sheet1,0);
$objPHPExcel->addExternalSheet($objPHPExcelFromCSV->getSheet(0),0);

$objWriter = PHPExcel_IOFactory::createWriter($objPHPExcel,
'Excel2007');
$objWriter->setIncludePivotTable(true);
$objWriter->save("test.xlsx");
