### PR TITLE
Double quote support for SUMIF()

### DIFF
--- a/Classes/PHPExcel/Calculation/MathTrig.php
+++ b/Classes/PHPExcel/Calculation/MathTrig.php
@@ -1164,7 +1164,11 @@ class PHPExcel_Calculation_MathTrig {
 		$condition = PHPExcel_Calculation_Functions::_ifCondition($condition);
 		// Loop through arguments
 		foreach ($aArgs as $key => $arg) {
-			if (!is_numeric($arg)) { $arg = PHPExcel_Calculation::_wrapResult(strtoupper($arg)); }
+			if (!is_numeric($arg)) {
+				$arg = str_replace('"', '""', $arg);
+				$arg = PHPExcel_Calculation::_wrapResult(strtoupper($arg));
+			}
+
 			$testCondition = '='.$arg.$condition;
 			if (PHPExcel_Calculation::getInstance()->_calculateFormulaValue($testCondition)) {
 				// Is it a value within our criteria

--- a/unitTests/Classes/PHPExcel/Calculation/MathTrigTest.php
+++ b/unitTests/Classes/PHPExcel/Calculation/MathTrigTest.php
@@ -479,6 +479,68 @@ class MathTrigTest extends PHPUnit_Framework_TestCase
     public function providerSQRTPI()
     {
     	return new testDataFileIterator('rawTestData/Calculation/MathTrig/SQRTPI.data');
+    }
+
+    /**
+     * @dataProvider providerSUMIF
+     */
+    public function testSUMIF()
+    {
+        $args = func_get_args();
+        $expectedResult = array_pop($args);
+        $result = call_user_func_array(array('PHPExcel_Calculation_MathTrig', 'SUMIF'), $args);
+        $this->assertEquals($expectedResult, $result, NULL, 1E-12);
+    }
+
+    public function providerSUMIF()
+    {
+        return array(
+            array(
+                array(
+                    array(1),
+                    array(5),
+                    array(10),
+                ),
+                '>=5',
+                15,
+            ),
+            array(
+                array(
+                    array('text'),
+                    array(2),
+                ),
+                '=text',
+                array(
+                    array(10),
+                    array(100),
+                ),
+                10,
+            ),
+            array(
+                array(
+                    array('"text with quotes"'),
+                    array(2),
+                ),
+                '=""text with quotes""',
+                array(
+                    array(10),
+                    array(100),
+                ),
+                10,
+            ),
+            array(
+                array(
+                    array('"text with quotes"'),
+                    array(''),
+                ),
+                '>""', // Compare to the single characater " (double quote)
+                array(
+                    array(10),
+                    array(100),
+                ),
+                10
+            ),
+        );
 	}
 
 }


### PR DESCRIPTION
SUMIF() should handle double quotes properly in both criteria and
cells values. This is especially useful when we need to compare string
containing themselve double quote(s).

As far as I know, the current implementation of testDataFileIterator does not allow nested array syntax. Thus I wrote the test data in PHP file instead. If it is actually possible to write them in .data files, please let me know the syntax.
