### PR TITLE
[Bugfix] Allow leading zeros

### DIFF
--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -92,7 +92,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
         } elseif (is_float($pValue) || is_int($pValue)) {
             return PHPExcel_Cell_DataType::TYPE_NUMERIC;
 
-        } elseif (preg_match('/^\-?([0-9]+\\.?[0-9]*|[0-9]*\\.?[0-9]+)$/', $pValue)) {
+        } elseif (preg_match('/^(\-|\+)?(([1-9]{1})([0-9]+)((?>\\.)[0-9]*)?)$/', $pValue)) {
             return PHPExcel_Cell_DataType::TYPE_NUMERIC;
 
         } elseif (is_string($pValue) && array_key_exists($pValue, PHPExcel_Cell_DataType::getErrorCodes())) {


### PR DESCRIPTION
When setting a `string` value only containing number and with leading zeros the actual regex will be matched and set the value type of the number type.
This will cause, when setting the cell, the conversion from `string` to `float` and the leading zeros will be removed.

The simple way I found to solve this issue is to change the regex in order when the first `number` is a zero inside a `string` the type of the value will stay the same (a `string`) otherwise change to  `number`.

Also I added the plus sign to the regex expression and add condition for the fraction part.
