### PR TITLE
Excel2007 writer's save() should return TRUE when file is successfully closed

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007.php
+++ b/Classes/PHPExcel/Writer/Excel2007.php
@@ -355,6 +355,8 @@ class PHPExcel_Writer_Excel2007 extends PHPExcel_Writer_Abstract implements PHPE
 			// Close file
 			if ($objZip->close() === false) {
 				throw new PHPExcel_Writer_Exception("Could not close zip file $pFilename.");
+			} else {
+				return true;
 			}
 
 			// If a temporary file was used, copy it to the correct file stream


### PR DESCRIPTION
I believe this should be put in place for all the other writers too, just haven't done this yet. Want to know if there's some form of coding practice you have in place that prevents these functions from returning a value before I put any time into modifying the other writers.

As it stands now, there is no way of knowing whether or not the `save` was successful. Or am I missing something? Should I be using a `try`-`catch` block?
