### PR TITLE
Infinite recursion on save after duplicating style from cell X (e.g. A1) to the same cell (A1)

### DIFF
--- a/Classes/PHPExcel/Style.php
+++ b/Classes/PHPExcel/Style.php
@@ -595,7 +595,7 @@ class PHPExcel_Style extends PHPExcel_Style_Supervisor implements PHPExcel_IComp
      */
     public function getQuotePrefix()
     {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getQuotePrefix();
 		}
         return $this->_quotePrefix;

--- a/Classes/PHPExcel/Style/Alignment.php
+++ b/Classes/PHPExcel/Style/Alignment.php
@@ -193,7 +193,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return string
 	 */
 	public function getHorizontal() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHorizontal();
 		}
 		return $this->_horizontal;
@@ -226,7 +226,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return string
 	 */
 	public function getVertical() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getVertical();
 		}
 		return $this->_vertical;
@@ -258,7 +258,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return int
 	 */
 	public function getTextRotation() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getTextRotation();
 		}
 		return $this->_textRotation;
@@ -298,7 +298,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return boolean
 	 */
 	public function getWrapText() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getWrapText();
 		}
 		return $this->_wrapText;
@@ -329,7 +329,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return boolean
 	 */
 	public function getShrinkToFit() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getShrinkToFit();
 		}
 		return $this->_shrinkToFit;
@@ -360,7 +360,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return int
 	 */
 	public function getIndent() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getIndent();
 		}
 		return $this->_indent;
@@ -395,7 +395,7 @@ class PHPExcel_Style_Alignment extends PHPExcel_Style_Supervisor implements PHPE
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/Border.php
+++ b/Classes/PHPExcel/Style/Border.php
@@ -281,7 +281,7 @@ class PHPExcel_Style_Border extends PHPExcel_Style_Supervisor implements PHPExce
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/Borders.php
+++ b/Classes/PHPExcel/Style/Borders.php
@@ -376,7 +376,7 @@ class PHPExcel_Style_Borders extends PHPExcel_Style_Supervisor implements PHPExc
      * @return int
      */
     public function getDiagonalDirection() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getDiagonalDirection();
 		}
     	return $this->_diagonalDirection;
@@ -407,7 +407,7 @@ class PHPExcel_Style_Borders extends PHPExcel_Style_Supervisor implements PHPExc
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashcode();
 		}
     	return md5(

--- a/Classes/PHPExcel/Style/Color.php
+++ b/Classes/PHPExcel/Style/Color.php
@@ -417,7 +417,7 @@ class PHPExcel_Style_Color extends PHPExcel_Style_Supervisor implements PHPExcel
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/Fill.php
+++ b/Classes/PHPExcel/Style/Fill.php
@@ -192,7 +192,7 @@ class PHPExcel_Style_Fill extends PHPExcel_Style_Supervisor implements PHPExcel_
 	 * @return string
 	 */
 	public function getFillType() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getFillType();
 		}
 		return $this->_fillType;
@@ -220,7 +220,7 @@ class PHPExcel_Style_Fill extends PHPExcel_Style_Supervisor implements PHPExcel_
 	 * @return double
 	 */
 	public function getRotation() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getRotation();
 		}
 		return $this->_rotation;
@@ -306,7 +306,7 @@ class PHPExcel_Style_Fill extends PHPExcel_Style_Supervisor implements PHPExcel_
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/Font.php
+++ b/Classes/PHPExcel/Style/Font.php
@@ -512,7 +512,7 @@ class PHPExcel_Style_Font extends PHPExcel_Style_Supervisor implements PHPExcel_
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -221,7 +221,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
 	 */
 	public function getBuiltInFormatCode()
 	{
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getBuiltInFormatCode();
 		}
 		return $this->_builtInFormatCode;
@@ -359,7 +359,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
 	 */
 	public function getHashCode()
 	{
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
 		return md5(

--- a/Classes/PHPExcel/Style/Protection.php
+++ b/Classes/PHPExcel/Style/Protection.php
@@ -138,7 +138,7 @@ class PHPExcel_Style_Protection extends PHPExcel_Style_Supervisor implements PHP
      * @return string
      */
     public function getLocked() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getLocked();
 		}
     	return $this->_locked;
@@ -166,7 +166,7 @@ class PHPExcel_Style_Protection extends PHPExcel_Style_Supervisor implements PHP
      * @return string
      */
     public function getHidden() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHidden();
 		}
     	return $this->_hidden;
@@ -194,7 +194,7 @@ class PHPExcel_Style_Protection extends PHPExcel_Style_Supervisor implements PHP
 	 * @return string	Hash code
 	 */
 	public function getHashCode() {
-		if ($this->_isSupervisor) {
+		if ($this->_isSupervisor && $this->getSharedComponent() !== $this) {
 			return $this->getSharedComponent()->getHashCode();
 		}
     	return md5(


### PR DESCRIPTION
This is basically a fix for this issue: http://stackoverflow.com/questions/18742595/phpexcel-style-fill-infinite-recursion ;

It is impossible to save a worksheet after duplicating a style from specific cell to the same cell. Let's take a look at the quick example of that issue:

```php
$phpe = new PHPExcel();
$sheet = $phpe->createSheet();

$sheet->setCellValue('A1', 'hi there') ;
$sheet->setCellValue('A2', 'hi again') ;

$sheet->duplicateStyle($sheet->getStyle('A1'), 'A2');
$sheet->duplicateStyle($sheet->getStyle('A1'), 'A1');

$writer = new PHPExcel_Writer_Excel2007($phpe);
$writer->save('./test.xlsx');
```

Expected result would be to have the worksheet saved to test.xlsx file. What happens instead is this:

```

PHP Fatal error:  Maximum function nesting level of '100' reached, aborting! in /var/www/opensource/PHPExcel/Classes/PHPExcel.php on line 94
PHP Stack trace:
PHP   1. {main}() /var/www/opensource/PHPExcel/test.php:0
PHP   2. PHPExcel_Writer_Excel2007->save() /var/www/opensource/PHPExcel/test.php:15
PHP   3. PHPExcel_HashTable->addFromSource() /var/www/opensource/PHPExcel/Classes/PHPExcel/Writer/Excel2007.php:202
PHP   4. PHPExcel_HashTable->add() /var/www/opensource/PHPExcel/Classes/PHPExcel/HashTable.php:81
PHP   5. PHPExcel_Style->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/HashTable.php:92
PHP   6. PHPExcel_Style_Fill->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/Style.php:636
PHP   7. PHPExcel_Style_Fill->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/Style/Fill.php:310
PHP   8. PHPExcel_Style_Fill->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/Style/Fill.php:310
PHP   9. PHPExcel_Style_Fill->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/Style/Fill.php:310
PHP  10. PHPExcel_Style_Fill->getHashCode() /var/www/opensource/PHPExcel/Classes/PHPExcel/Style/Fill.php:310
...
```

This is because after performing such a duplication, we come to a situation in which `$this->getSharedComponent === $this` is true in PHPExcel_Style_Fill and a bunch of other objects

However it works just fine after removing this line:

```php
$sheet->duplicateStyle($sheet->getStyle('A1'), 'A1');
```

So I added a necessary `$this !== $this->getSharedComponent()` check in every appropriate place, and it works just fine afterwards. 