### PR TITLE
When duplicating styles, styles shifted by one column to the right.

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -1512,7 +1512,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
         // Loop through cells and apply styles
         for ($col = $rangeStart[0]; $col <= $rangeEnd[0]; ++$col) {
             for ($row = $rangeStart[1]; $row <= $rangeEnd[1]; ++$row) {
-                $this->getCell(PHPExcel_Cell::stringFromColumnIndex($col) . $row)->setXfIndex($xfIndex);
+                $this->getCell(PHPExcel_Cell::stringFromColumnIndex($col - 1) . $row)->setXfIndex($xfIndex);
             }
         }
 


### PR DESCRIPTION
PHPExcel_Cell::rangeBoundaries -> PHPExcel_Cell::columnIndexFromString (Column index (base 1 !!!))
PHPExcel_Cell::stringFromColumnIndex Column index (base 0 !!!)
