### PR TITLE
ISTEXT() return wrong result if referencing an empty but formatted cell

### DIFF
--- a/Classes/PHPExcel/Cell.php
+++ b/Classes/PHPExcel/Cell.php
@@ -233,10 +233,12 @@ class PHPExcel_Cell
 	{
 		// set the value according to data type
 		switch ($pDataType) {
+			case PHPExcel_Cell_DataType::TYPE_NULL:
+				$this->_value = $pValue;
+				break;
 			case PHPExcel_Cell_DataType::TYPE_STRING2:
 				$pDataType = PHPExcel_Cell_DataType::TYPE_STRING;
 			case PHPExcel_Cell_DataType::TYPE_STRING:
-			case PHPExcel_Cell_DataType::TYPE_NULL:
 			case PHPExcel_Cell_DataType::TYPE_INLINE:
 				$this->_value = PHPExcel_Cell_DataType::checkString($pValue);
 				break;
@@ -379,7 +381,7 @@ class PHPExcel_Cell
     {
         return $this->_dataType == PHPExcel_Cell_DataType::TYPE_FORMULA;
     }
-    
+
 	/**
 	 *	Does this cell contain Data validation rules?
 	 *


### PR DESCRIPTION
ISTEXT should always return FALSE for empty cells, however PHPExcel returns
TRUE if the cell is formatted. This can be reproduced in Excel by choosing
formatting category "Text" for cell A1, and then in cell B1 input the
formula '=ISTEXT(A1)'. B1 will display FALSE, but PHPExcel will return TRUE.

This patch fix the NULL value being incorrectly cast to an empty string, and
thus eliminating ISTEXT() issue (and probably several others).
