### PR TITLE
Convert properties to string in OOCalc reader

### DIFF
--- a/Classes/PHPExcel/Reader/OOCalc.php
+++ b/Classes/PHPExcel/Reader/OOCalc.php
@@ -359,6 +359,7 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 				$officePropertyDC = $officePropertyData->children($namespacesMeta['dc']);
 			}
 			foreach($officePropertyDC as $propertyName => $propertyValue) {
+				$propertyValue = (string) $propertyValue;
 				switch ($propertyName) {
 					case 'title' :
 							$docProps->setTitle($propertyValue);
@@ -386,6 +387,7 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 			}
 			foreach($officePropertyMeta as $propertyName => $propertyValue) {
 				$propertyValueAttributes = $propertyValue->attributes($namespacesMeta['meta']);
+				$propertyValue = (string) $propertyValue;
 				switch ($propertyName) {
 					case 'initial-creator' :
 							$docProps->setCreator($propertyValue);


### PR DESCRIPTION
In the OOCalc reader, some properties that are read from meta.xml are copied to the DocumentProperties object as SimpleXMLElement instances, not as strings. This causes problems when e.g. serializing the worksheet object using PHP's `serialize()` function. The Excel2003XML does not seem to suffer from this, as all properties are converted to string or other simple data type before being copied.

The patch here resolves this by explicitly casting the property values to string before copying them.

[Here's a test ods file](https://www.dropbox.com/s/d9i131wwzlt6lkz/OOCalcReaderXML.ods) where the **creator** and **lastModifiedby** properties end up as SimpleXMLElement instances instead of strings, unless my patch is applied.
