### PR TITLE
BugFix Issue #248 - Excel2007 does not correctly mark rows as hidden

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -2055,11 +2055,11 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 		return $style;
 	}
 
-	private static function boolean($value = NULL)
+	private static function boolean($value = null)
 	{
-		if (is_numeric($value)) {
+		if (is_numeric($value) || is_object($value)) {
 			return (bool) $value;
 		}
-		return ($value === 'true' || $value === 'TRUE') ? TRUE : FALSE;
+		return ($value === 'true' || $value === 'TRUE') ? true : false;
 	}
 }


### PR DESCRIPTION
In the main loop of load method in Excel 2007
if you print a var_dump($col["hidden"])
you'll get this:

object(SimpleXMLElement)#13032 (1) {
  [0]=>
  string(1) "1"
}

So, the "self::boolean" method, does not work properly.
I fixed that method including the "is_object" check.
