### PR TITLE
Add ext-xmlwriter as a Composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     ],
     "require": {
         "php": ">=5.2.0",
-        "ext-xml": "*"
+        "ext-xml": "*",
+        "ext-xmlwriter": "*"
     },
     "recommend": {
         "ext-zip": "*",


### PR DESCRIPTION
XMLWriter is surprisingly a different extension from xml; and so is not installed on some systems (such as Gentoo).  This commit enforces it to be installed, since it's necessary for the functionality of PHPExcel.
