### PR TITLE
Add ability to set cachedHighestRow/HighestColumn

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -2839,6 +2839,16 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
             }
         }
     }
+    
+    public function setCachedHighestColumn($val) {
+        $this->_cachedHighestColumn = $val;
+    }
+    
+    public function setCachedHighestRow($val) {
+        $this->_cachedHighestRow = $val;
+    }
+    
+    
 /**
 	 * Define the code name of the sheet
 	 *


### PR DESCRIPTION
When executing $objWriter->generateSheetData(), html tables are sometimes generated with way too many columns and rows.  It would be nice to override this somehow.  Being able to update the highest column and row is one solution.  Another possible solution would be passing parameters to generateSheetData($worksheetDimensions).

	$objWorksheet = $objPHPExcel->getSheet($i);
	$objWorksheet->setCachedHighestColumn($maxCol);
	$objWorksheet->setCachedHighestRow($maxRow);
	$objWriter->setSheetIndex($i);
	$html = $objWriter->generateSheetData();