### PR TITLE
Double quote support for SUMIF() condition

### DIFF
--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -316,7 +316,12 @@ class PHPExcel_Calculation_Functions {
 		} else {
 			preg_match('/([<>=]+)(.*)/',$condition,$matches);
 			list(,$operator,$operand) = $matches;
-			if (!is_numeric($operand)) { $operand = PHPExcel_Calculation::_wrapResult(strtoupper($operand)); }
+
+			if (!is_numeric($operand)) {
+				$operand = str_replace('"', '""', $operand);
+				$operand = PHPExcel_Calculation::_wrapResult(strtoupper($operand));
+			}
+
 			return $operator.$operand;
 		}
 	}	//	function _ifCondition()

--- a/unitTests/Classes/PHPExcel/Calculation/MathTrigTest.php
+++ b/unitTests/Classes/PHPExcel/Calculation/MathTrigTest.php
@@ -521,7 +521,7 @@ class MathTrigTest extends PHPUnit_Framework_TestCase
                     array('"text with quotes"'),
                     array(2),
                 ),
-                '=""text with quotes""',
+                '="text with quotes"',
                 array(
                     array(10),
                     array(100),
@@ -533,12 +533,24 @@ class MathTrigTest extends PHPUnit_Framework_TestCase
                     array('"text with quotes"'),
                     array(''),
                 ),
-                '>""', // Compare to the single characater " (double quote)
+                '>"', // Compare to the single characater " (double quote)
                 array(
                     array(10),
                     array(100),
                 ),
                 10
+            ),
+            array(
+                array(
+                    array(''),
+                    array('anything'),
+                ),
+                '>"', // Compare to the single characater " (double quote)
+                array(
+                    array(10),
+                    array(100),
+                ),
+                100
             ),
         );
 	}


### PR DESCRIPTION
SUMIF() condition can have double quote, such as '=SUMIF(A2:A4,">""",B2:B4)'.
This formula purpose is to compare the character double quote (").

In our previous patch (commit f1a1f525) we wrongly assumed that
PHPExcel_Calculation_MathTrig::SUMIF() expected the condition to be escaped ('>""'),
but this is actually not the case in real use of PHPExcel, so the unit tests were
modified accordingly to use non-escaped condition ('>"').
