### PR TITLE
Added 'FIRST' location for different headers and footers images

### DIFF
--- a/Classes/PHPExcel/Worksheet/HeaderFooter.php
+++ b/Classes/PHPExcel/Worksheet/HeaderFooter.php
@@ -97,11 +97,17 @@ class PHPExcel_Worksheet_HeaderFooter
 {
 	/* Header/footer image location */
 	const IMAGE_HEADER_LEFT							= 'LH';
+        const IMAGE_HEADER_LEFT_FIRST						= 'LHFIRST';
 	const IMAGE_HEADER_CENTER						= 'CH';
+        const IMAGE_HEADER_CENTER_FIRST						= 'CHFIRST';
 	const IMAGE_HEADER_RIGHT						= 'RH';
+        const IMAGE_HEADER_RIGHT_FIRST						= 'RHFIRST';
 	const IMAGE_FOOTER_LEFT							= 'LF';
+        const IMAGE_FOOTER_LEFT_FIRST						= 'LFFIRST';
 	const IMAGE_FOOTER_CENTER						= 'CF';
+        const IMAGE_FOOTER_CENTER_FIRST						= 'CFFIRST';
 	const IMAGE_FOOTER_RIGHT						= 'RF';
+        const IMAGE_FOOTER_RIGHT_FIRST						= 'RFFIRST';
 
 	/**
 	 * OddHeader
@@ -439,11 +445,17 @@ class PHPExcel_Worksheet_HeaderFooter
     	// Sort array
     	$images = array();
     	if (isset($this->_headerFooterImages[self::IMAGE_HEADER_LEFT])) 	$images[self::IMAGE_HEADER_LEFT] = 		$this->_headerFooterImages[self::IMAGE_HEADER_LEFT];
-    	if (isset($this->_headerFooterImages[self::IMAGE_HEADER_CENTER])) 	$images[self::IMAGE_HEADER_CENTER] = 	$this->_headerFooterImages[self::IMAGE_HEADER_CENTER];
-    	if (isset($this->_headerFooterImages[self::IMAGE_HEADER_RIGHT])) 	$images[self::IMAGE_HEADER_RIGHT] = 	$this->_headerFooterImages[self::IMAGE_HEADER_RIGHT];
+        if (isset($this->_headerFooterImages[self::IMAGE_HEADER_LEFT_FIRST])) 	$images[self::IMAGE_HEADER_LEFT_FIRST] = 	$this->_headerFooterImages[self::IMAGE_HEADER_LEFT_FIRST];
+    	if (isset($this->_headerFooterImages[self::IMAGE_HEADER_CENTER])) 	$images[self::IMAGE_HEADER_CENTER] =            $this->_headerFooterImages[self::IMAGE_HEADER_CENTER];
+        if (isset($this->_headerFooterImages[self::IMAGE_HEADER_CENTER_FIRST])) $images[self::IMAGE_HEADER_CENTER_FIRST] = 	$this->_headerFooterImages[self::IMAGE_HEADER_CENTER_FIRST];
+    	if (isset($this->_headerFooterImages[self::IMAGE_HEADER_RIGHT])) 	$images[self::IMAGE_HEADER_RIGHT] =             $this->_headerFooterImages[self::IMAGE_HEADER_RIGHT];
+        if (isset($this->_headerFooterImages[self::IMAGE_HEADER_RIGHT_FIRST])) 	$images[self::IMAGE_HEADER_RIGHT_FIRST] = 	$this->_headerFooterImages[self::IMAGE_HEADER_RIGHT_FIRST];
     	if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_LEFT])) 	$images[self::IMAGE_FOOTER_LEFT] = 		$this->_headerFooterImages[self::IMAGE_FOOTER_LEFT];
-    	if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_CENTER])) 	$images[self::IMAGE_FOOTER_CENTER] = 	$this->_headerFooterImages[self::IMAGE_FOOTER_CENTER];
-    	if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT])) 	$images[self::IMAGE_FOOTER_RIGHT] = 	$this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT];
+        if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_LEFT_FIRST])) 	$images[self::IMAGE_FOOTER_LEFT_FIRST] = 	$this->_headerFooterImages[self::IMAGE_FOOTER_LEFT_FIRST];
+    	if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_CENTER])) 	$images[self::IMAGE_FOOTER_CENTER] =            $this->_headerFooterImages[self::IMAGE_FOOTER_CENTER];
+        if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_CENTER_FIRST])) $images[self::IMAGE_FOOTER_CENTER_FIRST] = 	$this->_headerFooterImages[self::IMAGE_FOOTER_CENTER_FIRST];
+    	if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT])) 	$images[self::IMAGE_FOOTER_RIGHT] =             $this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT];
+        if (isset($this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT_FIRST])) 	$images[self::IMAGE_FOOTER_RIGHT_FIRST] = 	$this->_headerFooterImages[self::IMAGE_FOOTER_RIGHT_FIRST];
     	$this->_headerFooterImages = $images;
 
     	return $this->_headerFooterImages;


### PR DESCRIPTION
I spent many days trying to set two different images for headers and footers when using setDifferentFirst(true) with no success.

I realized then there was no location set for the first image sections in Worksheet/HeaderFooter.php class. After unzipping an excel file, i just added the id's set by msoffice to the project. 

Now it has the ability to set a different image to the first header and footer.

Usage: 

```
$objPHPExcel->getActiveSheet()->getHeaderFooter()->setDifferentFirst(true);

// for regular H&F
$objPHPExcel->getActiveSheet()->getHeaderFooter()->addImage($objDrawing, PHPExcel_Worksheet_HeaderFooter::IMAGE_HEADER_LEFT);

// for first H&F
$objPHPExcel->getActiveSheet()->getHeaderFooter()->addImage($objDrawing, PHPExcel_Worksheet_HeaderFooter::IMAGE_HEADER_LEFT_FIRST);
```
