### PR TITLE
When libxmlloader options are the default values, disable the entity loader as well. CVE-2014-2054 by MITRE

### DIFF
--- a/Classes/PHPExcel/Settings.php
+++ b/Classes/PHPExcel/Settings.php
@@ -366,6 +366,7 @@ class PHPExcel_Settings
         if (is_null($options)) {
             $options = LIBXML_DTDLOAD | LIBXML_DTDATTR;
         }
+        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR)); 
         self::$_libXmlLoaderOptions = $options;
     } // function setLibXmlLoaderOptions
 
@@ -378,7 +379,7 @@ class PHPExcel_Settings
     public static function getLibXmlLoaderOptions()
     {
         if (is_null(self::$_libXmlLoaderOptions)) {
-            self::$_libXmlLoaderOptions = LIBXML_DTDLOAD | LIBXML_DTDATTR;
+            self::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR);
         }
         return self::$_libXmlLoaderOptions;
     } // function getLibXmlLoaderOptions


### PR DESCRIPTION
When libxmlloader options are the default values, disable the entity loader as well. CVE-2014-2054 by MITRE
