### PR TITLE
Fixes html entities to prevent parsing error of generated documentation.

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -670,7 +670,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 	/**
 	 * Generate CSS styles
 	 *
-	 * @param	boolean	$generateSurroundingHTML	Generate surrounding HTML tags? (<style> and </style>)
+	 * @param	boolean	$generateSurroundingHTML	Generate surrounding HTML tags? (&lt;style&gt; and &lt;/style&gt;)
 	 * @return	string
 	 * @throws	PHPExcel_Writer_Exception
 	 */


### PR DESCRIPTION
The html output contained "<.style.> and </.style.>" which causes a parse
error on stricter html validators. The solution was to swap < and > for
the equivalent html entities &lt; and &gt; respectivelly.

Signed-off-by: André Tannús
