### PR TITLE
Proposed fix for #335

### DIFF
--- a/Classes/PHPExcel.php
+++ b/Classes/PHPExcel.php
@@ -26,13 +26,6 @@
  */
 
 
-/** PHPExcel root directory */
-if (!defined('PHPEXCEL_ROOT')) {
-    define('PHPEXCEL_ROOT', dirname(__FILE__) . '/');
-    require(PHPEXCEL_ROOT . 'PHPExcel/Autoloader.php');
-}
-
-
 /**
  * PHPExcel
  *
@@ -356,6 +349,13 @@ class PHPExcel
 	 */
 	public function __construct()
 	{
+
+	    /** PHPExcel root directory */
+	    if (!defined('PHPEXCEL_ROOT')) {
+	      define('PHPEXCEL_ROOT', dirname(__FILE__) . '/');
+	      require(PHPEXCEL_ROOT . 'PHPExcel/Autoloader.php');
+	    }
+	    
 		$this->_uniqueID = uniqid();
 		$this->_calculationEngine	= PHPExcel_Calculation::getInstance($this);
 


### PR DESCRIPTION
Moved define to the constructor.

Tested in CI 2.0.3.1.

Doesn't matter if I use:

```
$excel = new PHPExcel();
```

or try to extend:

```
class E_PHPExcel extends PHPExcel {}
```

I get the following error:

```
Fatal error: Class 'PHPExcel_Calculation' not found in (...)/PHPExcel.php on line 360
```

Autoloader is not triggered, and I have to 'include_once'
 I have to include PHPExcel.php for example. Even though the class is found, the other classes are not loaded using the autoloader if i don't use 'require'/'include'_once PHPExcel.php explicitely

When I use the proposed solution, the classes are loaded using autoloader, without 'require' and excel is being generated

This seems to be working because:
http://stackoverflow.com/questions/2755500/php-require-class-call-from-inside-method
