### PR TITLE
TO FIX BUG INDEX WITH MATH = #N/A

### DIFF
--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -606,6 +606,10 @@ class PHPExcel_Calculation_LookupRef {
 			return PHPExcel_Calculation_Functions::VALUE();
 		}
 
+		if (PHPExcel_Calculation_Functions::IS_ERROR($rowNum)) {
+			return $rowNum;
+		}
+
 		if (!is_array($arrayValues)) {
 			return PHPExcel_Calculation_Functions::REF();
 		}


### PR DESCRIPTION
for exemple: =INDEX(C:C, MATCH(1,(A:A=M1)*(B:B=N1),0),0)
if Match return N/A, INDEX will return $arrayValues

To fix this I suggeste to return the ERROR code.
