### PR TITLE
Allow value of 0 to be passed into POISSON formula

### DIFF
--- a/Classes/PHPExcel/Calculation/Statistical.php
+++ b/Classes/PHPExcel/Calculation/Statistical.php
@@ -2737,7 +2737,7 @@ class PHPExcel_Calculation_Statistical {
 		$mean	= PHPExcel_Calculation_Functions::flattenSingleValue($mean);
 
 		if ((is_numeric($value)) && (is_numeric($mean))) {
-			if (($value <= 0) || ($mean <= 0)) {
+			if (($value < 0) || ($mean <= 0)) {
 				return PHPExcel_Calculation_Functions::NaN();
 			}
 			if ((is_numeric($cumulative)) || (is_bool($cumulative))) {


### PR DESCRIPTION
Excel 2007 accepts a value of 0 in the POISSON formula. The corresponding validations in PHP Excel returns a NaN error.

Example =POISSON(0, 0.263334117, FALSE) expected value is 0.768485091.
