### PR TITLE
Keep/set the value on _loadSheetsOnly as NULL ...

### DIFF
--- a/Classes/PHPExcel/Reader/Abstract.php
+++ b/Classes/PHPExcel/Reader/Abstract.php
@@ -145,8 +145,8 @@ abstract class PHPExcel_Reader_Abstract implements PHPExcel_Reader_IReader
 	 */
 	public function setLoadSheetsOnly($value = NULL)
 	{
-		$this->_loadSheetsOnly = is_array($value) ?
-			$value : array($value);
+		$this->_loadSheetsOnly = is_null($value) ? $value : (is_array($value) ?
+			$value : array($value));
 		return $this;
 	}
 


### PR DESCRIPTION
... when calling setLoadSheetsOnly() with NULL as argument (the default value) so that all worksheets are loaded, otherwise we'll end up getting an empty array, which means that no worksheet is loaded at all.
