### PR TITLE
Bug "Undefined variable: options"

### DIFF
--- a/Classes/PHPExcel/Settings.php
+++ b/Classes/PHPExcel/Settings.php
@@ -381,7 +381,7 @@ class PHPExcel_Settings
         if (is_null(self::$_libXmlLoaderOptions)) {
             self::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR);
         }
-        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
+        @libxml_disable_entity_loader(self::$_libXmlLoaderOptions == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
         return self::$_libXmlLoaderOptions;
     } // function getLibXmlLoaderOptions
 }


### PR DESCRIPTION
There is a bug for the var `$option`:

```
Notice: Undefined variable: options in [...]/vendor/phpoffice/phpexcel/Classes/PHPExcel/Settings.php on line 384
```

This bug is fixed with `self::$_libXmlLoaderOptions == (LIBXML_DTDLOAD | LIBXML_DTDATTR)` instead of `$options == (LIBXML_DTDLOAD | LIBXML_DTDATTR)`
