### PR TITLE
Prevent autoload clash when previous code has used spl_autoload_register

### DIFF
--- a/Classes/PHPExcel/Autoloader.php
+++ b/Classes/PHPExcel/Autoloader.php
@@ -55,7 +55,7 @@ class PHPExcel_Autoloader
             spl_autoload_register('__autoload');
         }
         //    Register ourselves with SPL
-        return spl_autoload_register(array('PHPExcel_Autoloader', 'Load'));
+        return spl_autoload_register(array('PHPExcel_Autoloader', 'Load'), true, true);
     }   //    function Register()
 
 


### PR DESCRIPTION
I was having difficulties using PHPExcel in my project as we already have an autoloader and we did not use the __autoload function. This change tells PHPExcel to prepend its autoloader on the autoload stack instead of appending it.
