### PR TITLE
Clarify prerequisites

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -27,11 +27,12 @@ Requirements
 
 The following requirements should be met prior to using PHPExcel:
 * PHP version 5.2.0 or higher
-* PHP extension php_zip enabled *)
-* PHP extension php_xml enabled
-* PHP extension php_gd2 enabled (if not compiled in)
+* PHP extension 'zip' enabled *)
+* PHP extensions 'xml', 'xmlreader', and 'xmlwriter' enabled
+* PHP extension 'gd' enabled (if not compiled in)
+ * Linked against GD version 2
 
-*) php_zip is only needed by PHPExcel_Reader_Excel2007, PHPExcel_Writer_Excel2007,
+*) The 'zip' extension is only needed by PHPExcel_Reader_Excel2007, PHPExcel_Writer_Excel2007,
    PHPExcel_Reader_OOCalc. In other words, if you need PHPExcel to handle .xlsx or .ods
    files you will need the zip extension, but otherwise not.
 


### PR DESCRIPTION
I'm setting up PHPExcel for the first time, and I found the prerequisites misleading, so I hope this helps clarify?

We'd also need to update this: https://github.com/PHPOffice/PHPExcel/wiki/Developer-Documentation-Prerequisites
But I'm not sure how to - but you can just copy my changes from install.txt

Hope this helps...
