### PR TITLE
Change the names of two variables on the examples, to make it camel case

### DIFF
--- a/Examples/33chartcreate-area.php
+++ b/Examples/33chartcreate-area.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -92,13 +92,13 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_AREACHART,				// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_PERCENT_STACKED,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),					// plotOrder
-	$dataseriesLabels,										// plotLabel
+	$dataSeriesLabels,										// plotLabel
 	$xAxisTickValues,										// plotCategory
 	$dataSeriesValues										// plotValues
 );
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_TOPRIGHT, NULL, false);
 
@@ -111,7 +111,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-bar-stacked.php
+++ b/Examples/33chartcreate-bar-stacked.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -92,7 +92,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STACKED,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues								// plotValues
 );
@@ -101,7 +101,7 @@ $series = new PHPExcel_Chart_DataSeries(
 $series->setPlotDirection(PHPExcel_Chart_DataSeries::DIRECTION_BAR);
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -114,7 +114,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-bar.php
+++ b/Examples/33chartcreate-bar.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -92,7 +92,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_CLUSTERED,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues								// plotValues
 );
@@ -101,7 +101,7 @@ $series = new PHPExcel_Chart_DataSeries(
 $series->setPlotDirection(PHPExcel_Chart_DataSeries::DIRECTION_BAR);
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -114,7 +114,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-column-2.php
+++ b/Examples/33chartcreate-column-2.php
@@ -67,7 +67,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	'Budget'
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	'Forecast'
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$E$1', NULL, 1),	//	'Actual'
@@ -100,7 +100,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_CLUSTERED,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues								// plotValues
 );
@@ -109,7 +109,7 @@ $series = new PHPExcel_Chart_DataSeries(
 $series->setPlotDirection(PHPExcel_Chart_DataSeries::DIRECTION_COL);
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_BOTTOM, NULL, false);
 
@@ -123,7 +123,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	$xAxisLabel,	// xAxisLabel

--- a/Examples/33chartcreate-column.php
+++ b/Examples/33chartcreate-column.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -92,7 +92,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues								// plotValues
 );
@@ -101,7 +101,7 @@ $series = new PHPExcel_Chart_DataSeries(
 $series->setPlotDirection(PHPExcel_Chart_DataSeries::DIRECTION_COL);
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -114,7 +114,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-composite.php
+++ b/Examples/33chartcreate-composite.php
@@ -68,13 +68,13 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels1 = array(
+$dataSeriesLabels1 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	Temperature
 );
-$dataseriesLabels2 = array(
+$dataSeriesLabels2 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	Rainfall
 );
-$dataseriesLabels3 = array(
+$dataSeriesLabels3 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	Humidity
 );
 
@@ -106,7 +106,7 @@ $series1 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_CLUSTERED,	// plotGrouping
 	range(0, count($dataSeriesValues1)-1),			// plotOrder
-	$dataseriesLabels1,								// plotLabel
+	$dataSeriesLabels1,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues1								// plotValues
 );
@@ -131,7 +131,7 @@ $series2 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_LINECHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
 	range(0, count($dataSeriesValues2)-1),			// plotOrder
-	$dataseriesLabels2,								// plotLabel
+	$dataSeriesLabels2,								// plotLabel
 	NULL,											// plotCategory
 	$dataSeriesValues2								// plotValues
 );
@@ -153,14 +153,14 @@ $series3 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_AREACHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
 	range(0, count($dataSeriesValues2)-1),			// plotOrder
-	$dataseriesLabels3,								// plotLabel
+	$dataSeriesLabels3,								// plotLabel
 	NULL,											// plotCategory
 	$dataSeriesValues3								// plotValues
 );
 
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series1, $series2, $series3));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series1, $series2, $series3));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -172,7 +172,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-line.php
+++ b/Examples/33chartcreate-line.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -92,13 +92,13 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_LINECHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STACKED,	// plotGrouping
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues								// plotValues
 );
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_TOPRIGHT, NULL, false);
 
@@ -111,7 +111,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-multiple-charts.php
+++ b/Examples/33chartcreate-multiple-charts.php
@@ -60,7 +60,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels1 = array(
+$dataSeriesLabels1 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -93,13 +93,13 @@ $series1 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_AREACHART,				// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_PERCENT_STACKED,	// plotGrouping
 	range(0, count($dataSeriesValues1)-1),					// plotOrder
-	$dataseriesLabels1,										// plotLabel
+	$dataSeriesLabels1,										// plotLabel
 	$xAxisTickValues1,										// plotCategory
 	$dataSeriesValues1										// plotValues
 );
 
 //	Set the series in the plot area
-$plotarea1 = new PHPExcel_Chart_PlotArea(NULL, array($series1));
+$plotArea1 = new PHPExcel_Chart_PlotArea(NULL, array($series1));
 //	Set the chart legend
 $legend1 = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_TOPRIGHT, NULL, false);
 
@@ -112,7 +112,7 @@ $chart1 = new PHPExcel_Chart(
 	'chart1',		// name
 	$title1,		// title
 	$legend1,		// legend
-	$plotarea1,		// plotArea
+	$plotArea1,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel
@@ -134,7 +134,7 @@ $objWorksheet->addChart($chart1);
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels2 = array(
+$dataSeriesLabels2 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -167,7 +167,7 @@ $series2 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_BARCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
 	range(0, count($dataSeriesValues2)-1),			// plotOrder
-	$dataseriesLabels2,								// plotLabel
+	$dataSeriesLabels2,								// plotLabel
 	$xAxisTickValues2,								// plotCategory
 	$dataSeriesValues2								// plotValues
 );
@@ -176,7 +176,7 @@ $series2 = new PHPExcel_Chart_DataSeries(
 $series2->setPlotDirection(PHPExcel_Chart_DataSeries::DIRECTION_COL);
 
 //	Set the series in the plot area
-$plotarea2 = new PHPExcel_Chart_PlotArea(NULL, array($series2));
+$plotArea2 = new PHPExcel_Chart_PlotArea(NULL, array($series2));
 //	Set the chart legend
 $legend2 = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -189,7 +189,7 @@ $chart2 = new PHPExcel_Chart(
 	'chart2',		// name
 	$title2,		// title
 	$legend2,		// legend
-	$plotarea2,		// plotArea
+	$plotArea2,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-pie.php
+++ b/Examples/33chartcreate-pie.php
@@ -60,7 +60,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels1 = array(
+$dataSeriesLabels1 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 );
 //	Set the X-Axis Labels
@@ -89,7 +89,7 @@ $series1 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_PIECHART,				// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,			// plotGrouping
 	range(0, count($dataSeriesValues1)-1),					// plotOrder
-	$dataseriesLabels1,										// plotLabel
+	$dataSeriesLabels1,										// plotLabel
 	$xAxisTickValues1,										// plotCategory
 	$dataSeriesValues1										// plotValues
 );
@@ -100,7 +100,7 @@ $layout1->setShowVal(TRUE);
 $layout1->setShowPercent(TRUE);
 
 //	Set the series in the plot area
-$plotarea1 = new PHPExcel_Chart_PlotArea($layout1, array($series1));
+$plotArea1 = new PHPExcel_Chart_PlotArea($layout1, array($series1));
 //	Set the chart legend
 $legend1 = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -112,7 +112,7 @@ $chart1 = new PHPExcel_Chart(
 	'chart1',		// name
 	$title1,		// title
 	$legend1,		// legend
-	$plotarea1,		// plotArea
+	$plotArea1,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel
@@ -134,7 +134,7 @@ $objWorksheet->addChart($chart1);
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels2 = array(
+$dataSeriesLabels2 = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 );
 //	Set the X-Axis Labels
@@ -163,7 +163,7 @@ $series2 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_DONUTCHART,		// plotType
 	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
 	range(0, count($dataSeriesValues2)-1),			// plotOrder
-	$dataseriesLabels2,								// plotLabel
+	$dataSeriesLabels2,								// plotLabel
 	$xAxisTickValues2,								// plotCategory
 	$dataSeriesValues2								// plotValues
 );
@@ -174,7 +174,7 @@ $layout2->setShowVal(TRUE);
 $layout2->setShowCatName(TRUE);
 
 //	Set the series in the plot area
-$plotarea2 = new PHPExcel_Chart_PlotArea($layout2, array($series2));
+$plotArea2 = new PHPExcel_Chart_PlotArea($layout2, array($series2));
 
 $title2 = new PHPExcel_Chart_Title('Test Donut Chart');
 
@@ -184,7 +184,7 @@ $chart2 = new PHPExcel_Chart(
 	'chart2',		// name
 	$title2,		// title
 	NULL,			// legend
-	$plotarea2,		// plotArea
+	$plotArea2,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-radar.php
+++ b/Examples/33chartcreate-radar.php
@@ -68,7 +68,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
 );
@@ -100,7 +100,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_RADARCHART,				// plotType
 	NULL,													// plotGrouping
 	range(0, count($dataSeriesValues)-1),					// plotOrder
-	$dataseriesLabels,										// plotLabel
+	$dataSeriesLabels,										// plotLabel
 	$xAxisTickValues,										// plotCategory
 	$dataSeriesValues,										// plotValues
 	NULL,													// smooth line
@@ -111,7 +111,7 @@ $series = new PHPExcel_Chart_DataSeries(
 $layout = new PHPExcel_Chart_Layout();
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea($layout, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea($layout, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -123,7 +123,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-scatter.php
+++ b/Examples/33chartcreate-scatter.php
@@ -59,7 +59,7 @@ $objWorksheet->fromArray(
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1),	//	2010
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1),	//	2011
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1),	//	2012
@@ -86,7 +86,7 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_SCATTERCHART,	// plotType
 	NULL,											// plotGrouping (Scatter charts don't have any grouping)
 	range(0, count($dataSeriesValues)-1),			// plotOrder
-	$dataseriesLabels,								// plotLabel
+	$dataSeriesLabels,								// plotLabel
 	$xAxisTickValues,								// plotCategory
 	$dataSeriesValues,								// plotValues
 	NULL,											// smooth line
@@ -94,7 +94,7 @@ $series = new PHPExcel_Chart_DataSeries(
 );
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_TOPRIGHT, NULL, false);
 
@@ -107,7 +107,7 @@ $chart = new PHPExcel_Chart(
 	'chart1',		// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	NULL,			// xAxisLabel

--- a/Examples/33chartcreate-stock.php
+++ b/Examples/33chartcreate-stock.php
@@ -62,7 +62,7 @@ $objWorksheet->getStyle('B2:E6')->getNumberFormat()->setFormatCode(PHPExcel_Styl
 //		Number of datapoints in series
 //		Data values
 //		Data Marker
-$dataseriesLabels = array(
+$dataSeriesLabels = array(
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$B$1', NULL, 1), //Max / Open
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$C$1', NULL, 1), //Min / Close
 	new PHPExcel_Chart_DataSeriesValues('String', 'Worksheet!$D$1', NULL, 1), //Min Threshold / Min
@@ -97,13 +97,13 @@ $series = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_STOCKCHART,	// plotType
 	null,										// plotGrouping - if we set this to not null, then xlsx throws error
 	range(0, count($dataSeriesValues)-1),		// plotOrder
-	$dataseriesLabels,							// plotLabel
+	$dataSeriesLabels,							// plotLabel
 	$xAxisTickValues,							// plotCategory
 	$dataSeriesValues							// plotValues
 );
 
 //	Set the series in the plot area
-$plotarea = new PHPExcel_Chart_PlotArea(NULL, array($series));
+$plotArea = new PHPExcel_Chart_PlotArea(NULL, array($series));
 //	Set the chart legend
 $legend = new PHPExcel_Chart_Legend(PHPExcel_Chart_Legend::POSITION_RIGHT, NULL, false);
 
@@ -116,7 +116,7 @@ $chart = new PHPExcel_Chart(
 	'stock-chart',	// name
 	$title,			// title
 	$legend,		// legend
-	$plotarea,		// plotArea
+	$plotArea,		// plotArea
 	true,			// plotVisibleOnly
 	0,				// displayBlanksAs
 	$xAxisLabel,	// xAxisLabel


### PR DESCRIPTION
Change the names of variables $plotarea and $dataseriesLabel to $plotArea and $dataSeriesLabel, respectively, to make it camel case compliant.
