### PR TITLE
Bugfix: Work item GH-351 - Change undefined variable to proper one

### DIFF
--- a/Classes/PHPExcel/Settings.php
+++ b/Classes/PHPExcel/Settings.php
@@ -366,7 +366,7 @@ class PHPExcel_Settings
         if (is_null($options)) {
             $options = LIBXML_DTDLOAD | LIBXML_DTDATTR;
         }
-        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR)); 
+        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
         self::$_libXmlLoaderOptions = $options;
     } // function setLibXmlLoaderOptions
 
@@ -381,7 +381,7 @@ class PHPExcel_Settings
         if (is_null(self::$_libXmlLoaderOptions)) {
             self::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR);
         }
-        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
+        @libxml_disable_entity_loader(self::$_libXmlLoaderOptions == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
         return self::$_libXmlLoaderOptions;
     } // function getLibXmlLoaderOptions
 }


### PR DESCRIPTION
Fix for issue #351. Looks like someone just copy the line `@libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR));` from setter but forget to set `$options = self::$_libXmlLoaderOptions` in this commit 6c8884b.
