### PR TITLE
GH-79 Move the rules of worksheet name restriction to a specific writer

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -439,17 +439,17 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
             throw new PHPExcel_Exception('Sheet code name cannot be empty.');
         }
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ] and  first and last characters cannot be a "'"
-        if ((str_replace(self::$_invalidCharacters, '', $pValue) !== $pValue) || 
-            (PHPExcel_Shared_String::Substring($pValue,-1,1)=='\'') || 
+        if ((str_replace(self::$_invalidCharacters, '', $pValue) !== $pValue) ||
+            (PHPExcel_Shared_String::Substring($pValue,-1,1)=='\'') ||
             (PHPExcel_Shared_String::Substring($pValue,0,1)=='\'')) {
             throw new PHPExcel_Exception('Invalid character found in sheet code name');
         }
- 
+
         // Maximum 31 characters allowed for sheet title
         if ($CharCount > 31) {
             throw new PHPExcel_Exception('Maximum 31 characters allowed in sheet code name.');
         }
- 
+
         return $pValue;
     }
 
@@ -465,11 +465,6 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ]
         if (str_replace(self::$_invalidCharacters, '', $pValue) !== $pValue) {
             throw new PHPExcel_Exception('Invalid character found in sheet title');
-        }
-
-        // Maximum 31 characters allowed for sheet title
-        if (PHPExcel_Shared_String::CountCharacters($pValue) > 31) {
-            throw new PHPExcel_Exception('Maximum 31 characters allowed in sheet title.');
         }
 
         return $pValue;
@@ -1216,8 +1211,8 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 		$cell = $this->_cellCollection->addCacheData(
 			$pCoordinate,
 			new PHPExcel_Cell(
-				NULL, 
-				PHPExcel_Cell_DataType::TYPE_NULL, 
+				NULL,
+				PHPExcel_Cell_DataType::TYPE_NULL,
 				$this
 			)
 		);
@@ -1244,7 +1239,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 
         return $cell;
 	}
-	
+
     /**
      * Does the cell at a specific coordinate exist?
      *
@@ -2859,7 +2854,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 		self::_checkSheetCodeName($pValue);
 
 		// We use the same code that setTitle to find a valid codeName else not using a space (Excel don't like) but a '_'
-		
+
         if ($this->getParent()) {
 			// Is there already such sheet name?
 			if ($this->getParent()->sheetCodeNameExists($pValue)) {

--- a/Classes/PHPExcel/Writer/Excel2007/DocProps.php
+++ b/Classes/PHPExcel/Writer/Excel2007/DocProps.php
@@ -101,7 +101,7 @@ class PHPExcel_Writer_Excel2007_DocProps extends PHPExcel_Writer_Excel2007_Write
 
 					$sheetCount = $pPHPExcel->getSheetCount();
 					for ($i = 0; $i < $sheetCount; ++$i) {
-						$objWriter->writeElement('vt:lpstr', $pPHPExcel->getSheet($i)->getTitle());
+						$objWriter->writeElement('vt:lpstr', PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pPHPExcel->getSheet($i)->getTitle()));
 					}
 
 				$objWriter->endElement();

--- a/Classes/PHPExcel/Writer/Excel2007/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Workbook.php
@@ -222,7 +222,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 			// sheet
 			$this->_writeSheet(
 				$objWriter,
-				$pPHPExcel->getSheet($i)->getTitle(),
+				PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pPHPExcel->getSheet($i)->getTitle()),
 				($i + 1),
 				($i + 1 + 3),
 				$pPHPExcel->getSheet($i)->getSheetState()
@@ -328,7 +328,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 		// Create absolute coordinate and write as raw text
 		$range = PHPExcel_Cell::splitRange($pNamedRange->getRange());
 		for ($i = 0; $i < count($range); $i++) {
-			$range[$i][0] = '\'' . str_replace("'", "''", $pNamedRange->getWorksheet()->getTitle()) . '\'!' . PHPExcel_Cell::absoluteReference($range[$i][0]);
+			$range[$i][0] = '\'' . str_replace("'", "''", PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pNamedRange->getWorksheet()->getTitle())) . '\'!' . PHPExcel_Cell::absoluteReference($range[$i][0]);
 			if (isset($range[$i][1])) {
 				$range[$i][1] = PHPExcel_Cell::absoluteReference($range[$i][1]);
 			}
@@ -370,7 +370,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 			$range[1] = PHPExcel_Cell::absoluteCoordinate($range[1]);
 			$range = implode(':', $range);
 
-			$objWriter->writeRawData('\'' . str_replace("'", "''", $pSheet->getTitle()) . '\'!' . $range);
+			$objWriter->writeRawData('\'' . str_replace("'", "''", PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle())) . '\'!' . $range);
 
 			$objWriter->endElement();
 		}
@@ -399,7 +399,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 			if ($pSheet->getPageSetup()->isColumnsToRepeatAtLeftSet()) {
 				$repeat = $pSheet->getPageSetup()->getColumnsToRepeatAtLeft();
 
-				$settingString .= '\'' . str_replace("'", "''", $pSheet->getTitle()) . '\'!$' . $repeat[0] . ':$' . $repeat[1];
+				$settingString .= '\'' . str_replace("'", "''", PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle())) . '\'!$' . $repeat[0] . ':$' . $repeat[1];
 			}
 
 			// Rows to repeat
@@ -410,7 +410,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 
 				$repeat = $pSheet->getPageSetup()->getRowsToRepeatAtTop();
 
-				$settingString .= '\'' . str_replace("'", "''", $pSheet->getTitle()) . '\'!$' . $repeat[0] . ':$' . $repeat[1];
+				$settingString .= '\'' . str_replace("'", "''", PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle())) . '\'!$' . $repeat[0] . ':$' . $repeat[1];
 			}
 
 			$objWriter->writeRawData($settingString);
@@ -445,7 +445,7 @@ class PHPExcel_Writer_Excel2007_Workbook extends PHPExcel_Writer_Excel2007_Write
 			foreach ($printArea as $printAreaRect) {
 				$printAreaRect[0] = PHPExcel_Cell::absoluteReference($printAreaRect[0]);
 				$printAreaRect[1] = PHPExcel_Cell::absoluteReference($printAreaRect[1]);
-				$chunks[] = '\'' . str_replace("'", "''", $pSheet->getTitle()) . '\'!' . implode(':', $printAreaRect);
+				$chunks[] = '\'' . str_replace("'", "''", PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle())) . '\'!' . implode(':', $printAreaRect);
 			}
 
 			$objWriter->writeRawData(implode(',', $chunks));

--- a/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
@@ -35,6 +35,8 @@
  */
 class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_WriterPart
 {
+    const MAX_NAME_LENGTH = 31;
+
 	/**
 	 * Write worksheet to XML format
 	 *
@@ -147,10 +149,10 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 	{
 		// sheetPr
 		$objWriter->startElement('sheetPr');
-		//$objWriter->writeAttribute('codeName',		$pSheet->getTitle());
+		//$objWriter->writeAttribute('codeName',		PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle()));
 		if($pSheet->getParent()->hasMacros()){//if the workbook have macros, we need to have codeName for the sheet
 			if($pSheet->hasCodeName()==false){
-				$pSheet->setCodeName($pSheet->getTitle());
+				$pSheet->setCodeName(PHPExcel_Writer_Excel2007_Worksheet::prepareSheetName($pSheet->getTitle()));
 			}
 			$objWriter->writeAttribute('codeName',		$pSheet->getCodeName());
 		}
@@ -1216,5 +1218,20 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
 			$objWriter->writeAttribute('r:id', 'rId_headerfooter_vml1');
 			$objWriter->endElement();
 		}
+	}
+
+	/**
+	 * Prepare name to write to a file
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	public static function prepareSheetName($name)
+	{
+        if (mb_strlen($name) > self::MAX_NAME_LENGTH) {
+            return mb_substr($name, 0, self::MAX_NAME_LENGTH);
+        }
+
+        return $name;
 	}
 }

--- a/Classes/PHPExcel/Writer/Excel5/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel5/Workbook.php
@@ -229,7 +229,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 		for ($i = 0; $i < $countSheets; ++$i) {
 			$phpSheet = $phpExcel->getSheet($i);
 
-			$this->_parser->setExtSheet($phpSheet->getTitle(), $i);  // Register worksheet name with parser
+			$this->_parser->setExtSheet(PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($phpSheet->getTitle()), $i);  // Register worksheet name with parser
 
 			$supbook_index = 0x00;
 			$ref = pack('vvv', $supbook_index, $i, $i);
@@ -487,7 +487,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 		// add size of Workbook globals part 2, the length of the SHEET records
 		$total_worksheets = count($this->_phpExcel->getAllSheets());
 		foreach ($this->_phpExcel->getWorksheetIterator() as $sheet) {
-			$offset += $boundsheet_length + strlen(PHPExcel_Shared_String::UTF8toBIFF8UnicodeShort($sheet->getTitle()));
+			$offset += $boundsheet_length + strlen(PHPExcel_Shared_String::UTF8toBIFF8UnicodeShort(PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($sheet->getTitle())));
 		}
 
 		// add the sizes of each of the Sheet substreams, respectively
@@ -548,7 +548,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 
 		// Create EXTERNSHEET for each worksheet
 		for ($i = 0; $i < $countSheets; ++$i) {
-			$this->_writeExternsheet($this->_phpExcel->getSheet($i)->getTitle());
+			$this->_writeExternsheet(PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($this->_phpExcel->getSheet($i)->getTitle()));
 		}
 	}
 
@@ -662,7 +662,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 				// Create absolute coordinate
 				$range = PHPExcel_Cell::splitRange($namedRange->getRange());
 				for ($i = 0; $i < count($range); $i++) {
-					$range[$i][0] = '\'' . str_replace("'", "''", $namedRange->getWorksheet()->getTitle()) . '\'!' . PHPExcel_Cell::absoluteCoordinate($range[$i][0]);
+					$range[$i][0] = '\'' . str_replace("'", "''", PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($namedRange->getWorksheet()->getTitle())) . '\'!' . PHPExcel_Cell::absoluteCoordinate($range[$i][0]);
 					if (isset($range[$i][1])) {
 						$range[$i][1] = PHPExcel_Cell::absoluteCoordinate($range[$i][1]);
 					}
@@ -924,7 +924,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 	 */
 	private function _writeBoundsheet($sheet, $offset)
 	{
-		$sheetname = $sheet->getTitle();
+		$sheetname = PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($sheet->getTitle());
 		$record    = 0x0085;                    // Record identifier
 
 		// sheet state

--- a/Classes/PHPExcel/Writer/Excel5/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel5/Worksheet.php
@@ -70,6 +70,8 @@
  */
 class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
 {
+    const MAX_NAME_LENGTH = 31;
+
 	/**
 	 * Formula parser
 	 *
@@ -1707,7 +1709,7 @@ class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
 		// References to the current sheet are encoded differently to references to
 		// external sheets.
 		//
-		if ($this->_phpSheet->getTitle() == $sheetname) {
+		if (PHPExcel_Writer_Excel5_Worksheet::prepareSheetName($this->_phpSheet->getTitle()) == $sheetname) {
 			$sheetname = '';
 			$length	= 0x02;  // The following 2 bytes
 			$cch	   = 1;	 // The following byte
@@ -3677,5 +3679,21 @@ class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
 		$data     .= pack('v', 0x0001);
 		$data     .= $cellRange;
 		$this->_append($header . $data);
+	}
+
+
+	/**
+	 * Prepare name to write to a file
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	public static function prepareSheetName($name)
+	{
+	    if (mb_strlen($name) > self::MAX_NAME_LENGTH) {
+	        return mb_substr($name, 0, self::MAX_NAME_LENGTH);
+	    }
+
+	    return $name;
 	}
 }


### PR DESCRIPTION
The dirty implementation for issue #79, it could be refactored to call `Specific_Worksheet_Writer.prepareSheetName` within `Worksheet.getTitle()` by injecting a writer to the Worksheet class.
