### PR TITLE
Add Mac CJK codepage definition.

### DIFF
--- a/Classes/PHPExcel/Shared/CodePage.php
+++ b/Classes/PHPExcel/Shared/CodePage.php
@@ -83,6 +83,9 @@ class PHPExcel_Shared_CodePage
 			case 1258:	return 'CP1258';			break;	//	ANSI Vietnamese
 			case 1361:	return 'CP1361';			break;	//	ANSI Korean (Johab)
 			case 10000:	return 'MAC';				break;	//	Apple Roman
+			case 10001:	return 'CP932';				break;	//	Macintosh Japanese
+			case 10002:	return 'CP950';				break;	//	Macintosh Chinese Traditional
+			case 10003:	return 'CP1361';			break;	//	Macintosh Korean
 			case 10006:	return 'MACGREEK';			break;	//	Macintosh Greek
 			case 10007:	return 'MACCYRILLIC';			break;	//	Macintosh Cyrillic
                         case 10008:	return 'CP936';				break;  //	Macintosh - Simplified Chinese (GB 2312)


### PR DESCRIPTION
10001 - Japanese
10002 - Chinese Traditional
10003 - Korean
