### PR TITLE
Open Document cell with not numeric formula

### DIFF
--- a/Classes/PHPExcel/Writer/OpenDocument/Content.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Content.php
@@ -205,12 +205,16 @@ class PHPExcel_Writer_OpenDocument_Content extends PHPExcel_Writer_OpenDocument_
 
                 case PHPExcel_Cell_DataType::TYPE_FORMULA:
                     try {
-                        $formula_value = PHPExcel_Calculation::getInstance()->calculateCellValue($cell);
+                        $formula_value = $cell->getCalculatedValue();
                     } catch (Exception $e) {
                         $formula_value = $cell->getValue();
                     }
                     $objWriter->writeAttribute('table:formula', 'of:' . $cell->getValue());
-                    $objWriter->writeAttribute('office:value-type', 'float');
+                    if (is_numeric($formula_value)) {
+                        $objWriter->writeAttribute('office:value-type', 'float');
+                    } else {
+                        $objWriter->writeAttribute('office:value-type', 'string');
+                    }
                     $objWriter->writeAttribute('office:value', $formula_value);
                     $objWriter->writeElement('text:p', $formula_value);
                     break;


### PR DESCRIPTION
Trying to write a Open Document with non numeric formula in a cell this exception was generated:
"XMLWriter::writeAttribute() expects parameter 2 to be string, array given"
The problem was that writer was using
PHPExcel_Calculation::getInstance()->calculateCellValue($cell);
instead of
$cell->getCalculatedValue();
