### PR TITLE
removed double encoded html tags

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -634,17 +634,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
         $objWriter->endElement();
       }
 
-      if (!is_null($majorGridlines->getLineStyleProperty(['arrow', 'head', 'type']))) {
+      if (!is_null($majorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')))) {
         $objWriter->startElement('a:headEnd');
-        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(['arrow', 'head', 'type']));
+        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')));
         $objWriter->writeAttribute('w', $majorGridlines->getLineStyleArrowParameters('head', 'w'));
         $objWriter->writeAttribute('len', $majorGridlines->getLineStyleArrowParameters('head', 'len'));
         $objWriter->endElement();
       }
 
-      if (!is_null($majorGridlines->getLineStyleProperty(['arrow', 'end', 'type']))) {
+      if (!is_null($majorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')))) {
         $objWriter->startElement('a:tailEnd');
-        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(['arrow', 'end', 'type']));
+        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')));
         $objWriter->writeAttribute('w', $majorGridlines->getLineStyleArrowParameters('end', 'w'));
         $objWriter->writeAttribute('len', $majorGridlines->getLineStyleArrowParameters('end', 'len'));
         $objWriter->endElement();
@@ -679,23 +679,23 @@ class PHPExcel_Writer_Excel2007_Chart extends
       if (!is_null($majorGridlines->getShadowProperty('algn'))) {
         $objWriter->writeAttribute('algn', $majorGridlines->getShadowProperty('algn'));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'sx']))) {
-        $objWriter->writeAttribute('sx', $majorGridlines->getShadowProperty(['size', 'sx']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'sx')))) {
+        $objWriter->writeAttribute('sx', $majorGridlines->getShadowProperty(array('size', 'sx')));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'sy']))) {
-        $objWriter->writeAttribute('sy', $majorGridlines->getShadowProperty(['size', 'sy']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'sy')))) {
+        $objWriter->writeAttribute('sy', $majorGridlines->getShadowProperty(array('size', 'sy')));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'kx']))) {
-        $objWriter->writeAttribute('kx', $majorGridlines->getShadowProperty(['size', 'kx']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'kx')))) {
+        $objWriter->writeAttribute('kx', $majorGridlines->getShadowProperty(array('size', 'kx')));
       }
       if (!is_null($majorGridlines->getShadowProperty('rotWithShape'))) {
         $objWriter->writeAttribute('rotWithShape', $majorGridlines->getShadowProperty('rotWithShape'));
       }
-      $objWriter->startElement("a:{$majorGridlines->getShadowProperty(['color', 'type'])}");
-      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(['color', 'value']));
+      $objWriter->startElement("a:{$majorGridlines->getShadowProperty(array('color', 'type'))}");
+      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(array('color', 'value')));
 
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(['color', 'alpha']));
+      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(array('color', 'alpha')));
       $objWriter->endElement(); //end alpha
 
       $objWriter->endElement(); //end color:type
@@ -741,17 +741,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
           $objWriter->endElement();
         }
 
-        if (!is_null($minorGridlines->getLineStyleProperty(['arrow', 'head', 'type']))) {
+        if (!is_null($minorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')))) {
           $objWriter->startElement('a:headEnd');
-          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(['arrow', 'head', 'type']));
+          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')));
           $objWriter->writeAttribute('w', $minorGridlines->getLineStyleArrowParameters('head', 'w'));
           $objWriter->writeAttribute('len', $minorGridlines->getLineStyleArrowParameters('head', 'len'));
           $objWriter->endElement();
         }
 
-        if (!is_null($minorGridlines->getLineStyleProperty(['arrow', 'end', 'type']))) {
+        if (!is_null($minorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')))) {
           $objWriter->startElement('a:tailEnd');
-          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(['arrow', 'end', 'type']));
+          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')));
           $objWriter->writeAttribute('w', $minorGridlines->getLineStyleArrowParameters('end', 'w'));
           $objWriter->writeAttribute('len', $minorGridlines->getLineStyleArrowParameters('end', 'len'));
           $objWriter->endElement();
@@ -787,22 +787,22 @@ class PHPExcel_Writer_Excel2007_Chart extends
         if (!is_null($minorGridlines->getShadowProperty('algn'))) {
           $objWriter->writeAttribute('algn', $minorGridlines->getShadowProperty('algn'));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'sx']))) {
-          $objWriter->writeAttribute('sx', $minorGridlines->getShadowProperty(['size', 'sx']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'sx')))) {
+          $objWriter->writeAttribute('sx', $minorGridlines->getShadowProperty(array('size', 'sx')));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'sy']))) {
-          $objWriter->writeAttribute('sy', $minorGridlines->getShadowProperty(['size', 'sy']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'sy')))) {
+          $objWriter->writeAttribute('sy', $minorGridlines->getShadowProperty(array('size', 'sy')));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'kx']))) {
-          $objWriter->writeAttribute('kx', $minorGridlines->getShadowProperty(['size', 'kx']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'kx')))) {
+          $objWriter->writeAttribute('kx', $minorGridlines->getShadowProperty(array('size', 'kx')));
         }
         if (!is_null($minorGridlines->getShadowProperty('rotWithShape'))) {
           $objWriter->writeAttribute('rotWithShape', $minorGridlines->getShadowProperty('rotWithShape'));
         }
-        $objWriter->startElement("a:{$minorGridlines->getShadowProperty(['color', 'type'])}");
-        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(['color', 'value']));
+        $objWriter->startElement("a:{$minorGridlines->getShadowProperty(array('color', 'type'))}");
+        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(array('color', 'value')));
         $objWriter->startElement('a:alpha');
-        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(['color', 'alpha']));
+        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(array('color', 'alpha')));
         $objWriter->endElement(); //end alpha
         $objWriter->endElement(); //end color:type
         $objWriter->endElement(); //end shadow
@@ -921,17 +921,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
       $objWriter->endElement();
     }
 
-    if (!is_null($xAxis->getLineStyleProperty(['arrow', 'head', 'type']))) {
+    if (!is_null($xAxis->getLineStyleProperty(array('arrow', 'head', 'type')))) {
       $objWriter->startElement('a:headEnd');
-      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(['arrow', 'head', 'type']));
+      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(array('arrow', 'head', 'type')));
       $objWriter->writeAttribute('w', $xAxis->getLineStyleArrowWidth('head'));
       $objWriter->writeAttribute('len', $xAxis->getLineStyleArrowLength('head'));
       $objWriter->endElement();
     }
 
-    if (!is_null($xAxis->getLineStyleProperty(['arrow', 'end', 'type']))) {
+    if (!is_null($xAxis->getLineStyleProperty(array('arrow', 'end', 'type')))) {
       $objWriter->startElement('a:tailEnd');
-      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(['arrow', 'end', 'type']));
+      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(array('arrow', 'end', 'type')));
       $objWriter->writeAttribute('w', $xAxis->getLineStyleArrowWidth('end'));
       $objWriter->writeAttribute('len', $xAxis->getLineStyleArrowLength('end'));
       $objWriter->endElement();
@@ -944,10 +944,10 @@ class PHPExcel_Writer_Excel2007_Chart extends
     if (!is_null($xAxis->getGlowProperty('size'))) {
       $objWriter->startElement('a:glow');
       $objWriter->writeAttribute('rad', $xAxis->getGlowProperty('size'));
-      $objWriter->startElement("a:{$xAxis->getGlowProperty(['color','type'])}");
-      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(['color','value']));
+      $objWriter->startElement("a:{$xAxis->getGlowProperty(array('color','type'))}");
+      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(array('color','value')));
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(['color','alpha']));
+      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(array('color','alpha')));
       $objWriter->endElement();
       $objWriter->endElement();
       $objWriter->endElement();
@@ -968,23 +968,23 @@ class PHPExcel_Writer_Excel2007_Chart extends
       if (!is_null($xAxis->getShadowProperty('algn'))) {
         $objWriter->writeAttribute('algn', $xAxis->getShadowProperty('algn'));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','sx']))) {
-        $objWriter->writeAttribute('sx', $xAxis->getShadowProperty(['size','sx']));
+      if (!is_null($xAxis->getShadowProperty(array('size','sx')))) {
+        $objWriter->writeAttribute('sx', $xAxis->getShadowProperty(array('size','sx')));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','sy']))) {
-        $objWriter->writeAttribute('sy', $xAxis->getShadowProperty(['size','sy']));
+      if (!is_null($xAxis->getShadowProperty(array('size','sy')))) {
+        $objWriter->writeAttribute('sy', $xAxis->getShadowProperty(array('size','sy')));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','kx']))) {
-        $objWriter->writeAttribute('kx', $xAxis->getShadowProperty(['size','kx']));
+      if (!is_null($xAxis->getShadowProperty(array('size','kx')))) {
+        $objWriter->writeAttribute('kx', $xAxis->getShadowProperty(array('size','kx')));
       }
       if (!is_null($xAxis->getShadowProperty('rotWithShape'))) {
         $objWriter->writeAttribute('rotWithShape', $xAxis->getShadowProperty('rotWithShape'));
       }
 
-      $objWriter->startElement("a:{$xAxis->getShadowProperty(['color','type'])}");
-      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(['color','value']));
+      $objWriter->startElement("a:{$xAxis->getShadowProperty(array('color','type'))}");
+      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(array('color','value')));
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(['color','alpha']));
+      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(array('color','alpha')));
       $objWriter->endElement();
       $objWriter->endElement();
 

--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -797,7 +797,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 			$column = -1;
 			while($column++ < $highestColumnIndex) {
 				$this->_columnWidths[$sheetIndex][$column] = 42; // approximation
-				$css['table.sheet' . $sheetIndex . ' col.col' . $column]['width'] = '42pt';
+				$css['table.sheet' . $sheetIndex . ' td.column' . $column]['min-width'] = '42pt';
 			}
 
 			// col elements, loop through columnDimensions and set width
@@ -806,11 +806,10 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 					$width = PHPExcel_Shared_Drawing::pixelsToPoints($width);
 					$column = PHPExcel_Cell::columnIndexFromString($columnDimension->getColumnIndex()) - 1;
 					$this->_columnWidths[$sheetIndex][$column] = $width;
-					$css['table.sheet' . $sheetIndex . ' col.col' . $column]['width'] = $width . 'pt';
-
+					$css['table.sheet' . $sheetIndex . ' td.column' . $column]['min-width'] = $width . 'pt';
 					if ($columnDimension->getVisible() === false) {
-						$css['table.sheet' . $sheetIndex . ' col.col' . $column]['visibility'] = 'collapse';
-						$css['table.sheet' . $sheetIndex . ' col.col' . $column]['*display'] = 'none'; // target IE6+7
+						$css['table.sheet' . $sheetIndex . ' td.column' . $column]['visibility'] = 'collapse';
+						$css['table.sheet' . $sheetIndex . ' td.column' . $column]['*display'] = 'none'; // target IE6+7
 					}
 				}
 			}
@@ -1043,8 +1042,8 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 				if (!$this->_useInlineCss) {
 					$html .= '		<col class="col' . $i . '">' . PHP_EOL;
 				} else {
-					$style = isset($this->_cssStyles['table.sheet' . $sheetIndex . ' col.col' . $i]) ?
-						$this->_assembleCSS($this->_cssStyles['table.sheet' . $sheetIndex . ' col.col' . $i]) : '';
+					$style = isset($this->_cssStyles['table.sheet' . $sheetIndex . ' td.column' . $i]) ?
+						$this->_assembleCSS($this->_cssStyles['table.sheet' . $sheetIndex . ' td.column' . $i]) : '';
 					$html .= '		<col style="' . $style . '">' . PHP_EOL;
 				}
 			}

--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -1176,13 +1176,12 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 								array($this, 'formatColor')
 							);
 						} else {
-							$cellData = PHPExcel_Style_NumberFormat::ToFormattedString(
+							$cellData = PHPExcel_Style_NumberFormat::toFormattedString(
 								$cell->getValue(),
 								$pSheet->getParent()->getCellXfByIndex( $cell->getXfIndex() )->getNumberFormat()->getFormatCode(),
 								array($this, 'formatColor')
 							);
 						}
-						$cellData = htmlspecialchars($cellData);
 						if ($pSheet->getParent()->getCellXfByIndex( $cell->getXfIndex() )->getFont()->getSuperScript()) {
 							$cellData = '<sup>'.$cellData.'</sup>';
 						} elseif ($pSheet->getParent()->getCellXfByIndex( $cell->getXfIndex() )->getFont()->getSubScript()) {


### PR DESCRIPTION
The former line 1185: `$cellData = htmlspecialchars($cellData);` is double-encoding HTML tags when conditional colors are passed to the NumberFormat (like "0;[Red] 0"). The `PHPExcel_Style_NumberFormat::formatColor` callback, present in all occasions already encodes HTML content within the cell value (line 1408).

Also, there's a minor typo in the `PHPExcel_Style_NumberFormat::ToFormattedString` (the method uses a lowercase **t**).
