### PR TITLE
Use normal array syntax to support PHP <5.4 (fixes #411)

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -634,17 +634,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
         $objWriter->endElement();
       }
 
-      if (!is_null($majorGridlines->getLineStyleProperty(['arrow', 'head', 'type']))) {
+      if (!is_null($majorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')))) {
         $objWriter->startElement('a:headEnd');
-        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(['arrow', 'head', 'type']));
+        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')));
         $objWriter->writeAttribute('w', $majorGridlines->getLineStyleArrowParameters('head', 'w'));
         $objWriter->writeAttribute('len', $majorGridlines->getLineStyleArrowParameters('head', 'len'));
         $objWriter->endElement();
       }
 
-      if (!is_null($majorGridlines->getLineStyleProperty(['arrow', 'end', 'type']))) {
+      if (!is_null($majorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')))) {
         $objWriter->startElement('a:tailEnd');
-        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(['arrow', 'end', 'type']));
+        $objWriter->writeAttribute('type', $majorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')));
         $objWriter->writeAttribute('w', $majorGridlines->getLineStyleArrowParameters('end', 'w'));
         $objWriter->writeAttribute('len', $majorGridlines->getLineStyleArrowParameters('end', 'len'));
         $objWriter->endElement();
@@ -679,23 +679,23 @@ class PHPExcel_Writer_Excel2007_Chart extends
       if (!is_null($majorGridlines->getShadowProperty('algn'))) {
         $objWriter->writeAttribute('algn', $majorGridlines->getShadowProperty('algn'));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'sx']))) {
-        $objWriter->writeAttribute('sx', $majorGridlines->getShadowProperty(['size', 'sx']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'sx')))) {
+        $objWriter->writeAttribute('sx', $majorGridlines->getShadowProperty(array('size', 'sx')));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'sy']))) {
-        $objWriter->writeAttribute('sy', $majorGridlines->getShadowProperty(['size', 'sy']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'sy')))) {
+        $objWriter->writeAttribute('sy', $majorGridlines->getShadowProperty(array('size', 'sy')));
       }
-      if (!is_null($majorGridlines->getShadowProperty(['size', 'kx']))) {
-        $objWriter->writeAttribute('kx', $majorGridlines->getShadowProperty(['size', 'kx']));
+      if (!is_null($majorGridlines->getShadowProperty(array('size', 'kx')))) {
+        $objWriter->writeAttribute('kx', $majorGridlines->getShadowProperty(array('size', 'kx')));
       }
       if (!is_null($majorGridlines->getShadowProperty('rotWithShape'))) {
         $objWriter->writeAttribute('rotWithShape', $majorGridlines->getShadowProperty('rotWithShape'));
       }
-      $objWriter->startElement("a:{$majorGridlines->getShadowProperty(['color', 'type'])}");
-      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(['color', 'value']));
+      $objWriter->startElement("a:{$majorGridlines->getShadowProperty(array('color', 'type'))}");
+      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(array('color', 'value')));
 
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(['color', 'alpha']));
+      $objWriter->writeAttribute('val', $majorGridlines->getShadowProperty(array('color', 'alpha')));
       $objWriter->endElement(); //end alpha
 
       $objWriter->endElement(); //end color:type
@@ -741,17 +741,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
           $objWriter->endElement();
         }
 
-        if (!is_null($minorGridlines->getLineStyleProperty(['arrow', 'head', 'type']))) {
+        if (!is_null($minorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')))) {
           $objWriter->startElement('a:headEnd');
-          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(['arrow', 'head', 'type']));
+          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(array('arrow', 'head', 'type')));
           $objWriter->writeAttribute('w', $minorGridlines->getLineStyleArrowParameters('head', 'w'));
           $objWriter->writeAttribute('len', $minorGridlines->getLineStyleArrowParameters('head', 'len'));
           $objWriter->endElement();
         }
 
-        if (!is_null($minorGridlines->getLineStyleProperty(['arrow', 'end', 'type']))) {
+        if (!is_null($minorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')))) {
           $objWriter->startElement('a:tailEnd');
-          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(['arrow', 'end', 'type']));
+          $objWriter->writeAttribute('type', $minorGridlines->getLineStyleProperty(array('arrow', 'end', 'type')));
           $objWriter->writeAttribute('w', $minorGridlines->getLineStyleArrowParameters('end', 'w'));
           $objWriter->writeAttribute('len', $minorGridlines->getLineStyleArrowParameters('end', 'len'));
           $objWriter->endElement();
@@ -787,22 +787,22 @@ class PHPExcel_Writer_Excel2007_Chart extends
         if (!is_null($minorGridlines->getShadowProperty('algn'))) {
           $objWriter->writeAttribute('algn', $minorGridlines->getShadowProperty('algn'));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'sx']))) {
-          $objWriter->writeAttribute('sx', $minorGridlines->getShadowProperty(['size', 'sx']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'sx')))) {
+          $objWriter->writeAttribute('sx', $minorGridlines->getShadowProperty(array('size', 'sx')));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'sy']))) {
-          $objWriter->writeAttribute('sy', $minorGridlines->getShadowProperty(['size', 'sy']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'sy')))) {
+          $objWriter->writeAttribute('sy', $minorGridlines->getShadowProperty(array('size', 'sy')));
         }
-        if (!is_null($minorGridlines->getShadowProperty(['size', 'kx']))) {
-          $objWriter->writeAttribute('kx', $minorGridlines->getShadowProperty(['size', 'kx']));
+        if (!is_null($minorGridlines->getShadowProperty(array('size', 'kx')))) {
+          $objWriter->writeAttribute('kx', $minorGridlines->getShadowProperty(array('size', 'kx')));
         }
         if (!is_null($minorGridlines->getShadowProperty('rotWithShape'))) {
           $objWriter->writeAttribute('rotWithShape', $minorGridlines->getShadowProperty('rotWithShape'));
         }
-        $objWriter->startElement("a:{$minorGridlines->getShadowProperty(['color', 'type'])}");
-        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(['color', 'value']));
+        $objWriter->startElement("a:{$minorGridlines->getShadowProperty(array('color', 'type'))}");
+        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(array('color', 'value')));
         $objWriter->startElement('a:alpha');
-        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(['color', 'alpha']));
+        $objWriter->writeAttribute('val', $minorGridlines->getShadowProperty(array('color', 'alpha')));
         $objWriter->endElement(); //end alpha
         $objWriter->endElement(); //end color:type
         $objWriter->endElement(); //end shadow
@@ -921,17 +921,17 @@ class PHPExcel_Writer_Excel2007_Chart extends
       $objWriter->endElement();
     }
 
-    if (!is_null($xAxis->getLineStyleProperty(['arrow', 'head', 'type']))) {
+    if (!is_null($xAxis->getLineStyleProperty(array('arrow', 'head', 'type')))) {
       $objWriter->startElement('a:headEnd');
-      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(['arrow', 'head', 'type']));
+      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(array('arrow', 'head', 'type')));
       $objWriter->writeAttribute('w', $xAxis->getLineStyleArrowWidth('head'));
       $objWriter->writeAttribute('len', $xAxis->getLineStyleArrowLength('head'));
       $objWriter->endElement();
     }
 
-    if (!is_null($xAxis->getLineStyleProperty(['arrow', 'end', 'type']))) {
+    if (!is_null($xAxis->getLineStyleProperty(array('arrow', 'end', 'type')))) {
       $objWriter->startElement('a:tailEnd');
-      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(['arrow', 'end', 'type']));
+      $objWriter->writeAttribute('type', $xAxis->getLineStyleProperty(array('arrow', 'end', 'type')));
       $objWriter->writeAttribute('w', $xAxis->getLineStyleArrowWidth('end'));
       $objWriter->writeAttribute('len', $xAxis->getLineStyleArrowLength('end'));
       $objWriter->endElement();
@@ -944,10 +944,10 @@ class PHPExcel_Writer_Excel2007_Chart extends
     if (!is_null($xAxis->getGlowProperty('size'))) {
       $objWriter->startElement('a:glow');
       $objWriter->writeAttribute('rad', $xAxis->getGlowProperty('size'));
-      $objWriter->startElement("a:{$xAxis->getGlowProperty(['color','type'])}");
-      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(['color','value']));
+      $objWriter->startElement("a:{$xAxis->getGlowProperty(array('color','type'))}");
+      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(array('color','value')));
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(['color','alpha']));
+      $objWriter->writeAttribute('val', $xAxis->getGlowProperty(array('color','alpha')));
       $objWriter->endElement();
       $objWriter->endElement();
       $objWriter->endElement();
@@ -968,23 +968,23 @@ class PHPExcel_Writer_Excel2007_Chart extends
       if (!is_null($xAxis->getShadowProperty('algn'))) {
         $objWriter->writeAttribute('algn', $xAxis->getShadowProperty('algn'));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','sx']))) {
-        $objWriter->writeAttribute('sx', $xAxis->getShadowProperty(['size','sx']));
+      if (!is_null($xAxis->getShadowProperty(array('size','sx')))) {
+        $objWriter->writeAttribute('sx', $xAxis->getShadowProperty(array('size','sx')));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','sy']))) {
-        $objWriter->writeAttribute('sy', $xAxis->getShadowProperty(['size','sy']));
+      if (!is_null($xAxis->getShadowProperty(array('size','sy')))) {
+        $objWriter->writeAttribute('sy', $xAxis->getShadowProperty(array('size','sy')));
       }
-      if (!is_null($xAxis->getShadowProperty(['size','kx']))) {
-        $objWriter->writeAttribute('kx', $xAxis->getShadowProperty(['size','kx']));
+      if (!is_null($xAxis->getShadowProperty(array('size','kx')))) {
+        $objWriter->writeAttribute('kx', $xAxis->getShadowProperty(array('size','kx')));
       }
       if (!is_null($xAxis->getShadowProperty('rotWithShape'))) {
         $objWriter->writeAttribute('rotWithShape', $xAxis->getShadowProperty('rotWithShape'));
       }
 
-      $objWriter->startElement("a:{$xAxis->getShadowProperty(['color','type'])}");
-      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(['color','value']));
+      $objWriter->startElement("a:{$xAxis->getShadowProperty(array('color','type'))}");
+      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(array('color','value')));
       $objWriter->startElement('a:alpha');
-      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(['color','alpha']));
+      $objWriter->writeAttribute('val', $xAxis->getShadowProperty(array('color','alpha')));
       $objWriter->endElement();
       $objWriter->endElement();
 


### PR DESCRIPTION
Use traditional syntax for arrays to support PHP < 5.4. The affected code was introduced in #404.

Fixes #411
