### PR TITLE
Fix invalid NA return in VLOOKUP

### DIFF
--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -735,11 +735,7 @@ class PHPExcel_Calculation_LookupRef {
 				return PHPExcel_Calculation_Functions::NA();
 			} else {
 				//	otherwise return the appropriate value
-				$result = $lookup_array[$rowNumber][$returnColumn];
-				if ((is_numeric($lookup_value) && is_numeric($result)) ||
-					(!is_numeric($lookup_value) && !is_numeric($result))) {
-					return $result;
-				}
+				return $lookup_array[$rowNumber][$returnColumn];
 			}
 		}
 
@@ -802,8 +798,7 @@ class PHPExcel_Calculation_LookupRef {
                 return PHPExcel_Calculation_Functions::NA();
             } else {
                 //  otherwise return the appropriate value
-                $result = $lookup_array[$returnColumn][$rowNumber];
-				return $result;
+                return $lookup_array[$returnColumn][$rowNumber];
             }
         }
 


### PR DESCRIPTION
The VLOOKUP function required the lookup value to be the same type as the return value which has been corrected.

Removed redundant $result variable
