### PR TITLE
Create image resource only when needed

### DIFF
--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -920,9 +920,8 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 							// need check because some blip types are not supported by Escher reader such as EMF
 							if ($blip = $BSE->getBlip()) {
-								$ih = imagecreatefromstring($blip->getData());
 								$drawing = new PHPExcel_Worksheet_MemoryDrawing();
-								$drawing->setImageResource($ih);
+								$drawing->setImageResourceData($blip->getData());
 
 								// width, height, offsetX, offsetY
 								$drawing->setResizeProportional(false);


### PR DESCRIPTION
I had a problem with excel file full of images (and one big one). I didn't need most of the images, but PHPExcel tried to create image resource for every image. Moreover, I needed just to save image on disk, so I didn't need at all to create image resource.

I found a way to optimize it. PHPExcel_Worksheet_MemoryDrawing can store internally image string and create image resource only when it is needed. It can retrieve image size and image type based on this string, still without creating image resource.

BTW: I didn't know if you use tabs or spaces for indents ;)
BTW2: There is no tests for drawing classes, so I couldn't test it properly.
