### PR TITLE
Remove libxml_disable_entity_loader from getLibXmlLoaderOptions()

### DIFF
--- a/Classes/PHPExcel/Settings.php
+++ b/Classes/PHPExcel/Settings.php
@@ -381,7 +381,6 @@ class PHPExcel_Settings
         if (is_null(self::$_libXmlLoaderOptions)) {
             self::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR);
         }
-        @libxml_disable_entity_loader($options == (LIBXML_DTDLOAD | LIBXML_DTDATTR));
         return self::$_libXmlLoaderOptions;
     } // function getLibXmlLoaderOptions
 }


### PR DESCRIPTION
$options in this line can't possibly exist. Further, there's no reason to call libxml_disable_entity_loader from a getter - this looks like a copy/paste mistake.

Nuking the line in question breaks no unit tests.
