### PR TITLE
Fixing Pie Chart example to display pie charts

### DIFF
--- a/Examples/33chartcreate-pie.php
+++ b/Examples/33chartcreate-pie.php
@@ -87,7 +87,7 @@ $dataSeriesValues1 = array(
 //	Build the dataseries
 $series1 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_PIECHART,				// plotType
-	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,			// plotGrouping
+	NULL,           							// plotGrouping
 	range(0, count($dataSeriesValues1)-1),					// plotOrder
 	$dataSeriesLabels1,										// plotLabel
 	$xAxisTickValues1,										// plotCategory
@@ -161,7 +161,7 @@ $dataSeriesValues2 = array(
 //	Build the dataseries
 $series2 = new PHPExcel_Chart_DataSeries(
 	PHPExcel_Chart_DataSeries::TYPE_DONUTCHART,		// plotType
-	PHPExcel_Chart_DataSeries::GROUPING_STANDARD,	// plotGrouping
+	NULL,							// plotGrouping
 	range(0, count($dataSeriesValues2)-1),			// plotOrder
 	$dataSeriesLabels2,								// plotLabel
 	$xAxisTickValues2,								// plotCategory


### PR DESCRIPTION
I have noticed that this example is currently throwing the following error when opening the produced Excel Spreadsheet -  "We found a problem with some content in <filename>.xlsx. Do you want us to try to recover as much as we can? If you trust the source of this workbook click Yes". 

In order to fix this I have set the removed the PlotGrouping setting (currently PHPExcel_Chart_DataSeries::GROUPING_STANDARD) to NULL and it appears to work.
