### PR TITLE
CP21454 "No Impact" conditional formatting fix for NumberFormat

### DIFF
--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -120,6 +120,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
 
 		if ($isConditional) {
 			$this->_formatCode = NULL;
+			$this->_builtInFormatCode = FALSE;
 		}
 	}
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -42,6 +42,7 @@ Planned for v1.8.1
 - Feature:  (CQD)             Work Item GH-389  - Additional Mac CJK codepage definitions
 - Feature:  (bolovincev)      Work Item GH-269  - Update Worksheet.php getStyleByColumnAndRow() to allow a range of cells rather than just a single cell
 - Feature:  (MBaker)                            - New methods added for testing cell status within merge groups
+- Bugfix:   (wiseloren)       Work Item CP21454 - "No Impact" conditional formatting fix for NumberFormat
 
 
 2014-03-02 (v1.8.0):


### PR DESCRIPTION
This is a partial fix for: https://phpexcel.codeplex.com/workitem/21454  (It fully fixes numberFormat but does not fix "no impact" for other styles like alignment.)
