### PR TITLE
Ignore contents of style tags

### DIFF
--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -389,6 +389,8 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
 						$this->_tableLevel = 0;
 						$this->_processDomElement($child,$sheet,$row,$column,$cellContent);
 						break;
+					case 'style' :
+						break;
 					default:
 						$this->_processDomElement($child,$sheet,$row,$column,$cellContent);
 				}


### PR DESCRIPTION
I have an HTML .xls file that contains a <style> tag, the contents of which appear when extracting data from the spreadsheet.  This change makes it skip the contents of <style> tags.
