### PR TITLE
Fix wrong logic in VLOOKUP

### DIFF
--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -736,10 +736,7 @@ class PHPExcel_Calculation_LookupRef {
 			} else {
 				//	otherwise return the appropriate value
 				$result = $lookup_array[$rowNumber][$returnColumn];
-				if ((is_numeric($lookup_value) && is_numeric($result)) ||
-					(!is_numeric($lookup_value) && !is_numeric($result))) {
-					return $result;
-				}
+				return $result;
 			}
 		}
 


### PR DESCRIPTION
Before:
- If lookup value was numeric, the return value also had to be numeric.
- If the lookup value wasn't numeric, the return value also couldn't be numeric.

This doesn't make sense. What is returned does not and should not depend in any way on the type of what is being looked for. The [documentation](http://office.microsoft.com/en-us/excel-help/vlookup-HP005209335.aspx) also doesn't mention anything about this.

The behaviour of `VLOOKUP` is now also matching the behaviour of `HLOOKUP`.

See also #385.
