### PR TITLE
vlookup - incorrect value when not exact match

### DIFF
--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -725,8 +725,14 @@ class PHPExcel_Calculation_LookupRef {
 				(!is_numeric($lookup_value) && !is_numeric($rowData[$firstColumn]) && (strtolower($rowData[$firstColumn]) > strtolower($lookup_value)))) {
 				break;
 			}
-			$rowNumber = $rowKey;
-			$rowValue = $rowData[$firstColumn];
+			
+			// remember the last key, but only if datatypes match
+			if ((is_numeric($lookup_value) && is_numeric($rowData[$firstColumn])) ||
+				(!is_numeric($lookup_value) && !is_numeric($rowData[$firstColumn])))
+			{
+				$rowNumber = $rowKey;
+				$rowValue = $rowData[$firstColumn];
+			}
 		}
 
 		if ($rowNumber !== false) {


### PR DESCRIPTION
I ran into a problem when using vlookup function. 
My lookup table looks like this:
![image](https://cloud.githubusercontent.com/assets/9688327/5074704/e7a85dc2-6e5a-11e4-9810-64746e8c9412.png)
and I am looking up value for 65. PHPExcel returns 67, but it should return 27.9

I fixed it by adding an extra check to make sure that the datatypes of the lookup table key vs. the value being looked up match.

Hope this is helpful.

