### PR TITLE
Make sure that the number format actually is built in when loading Excel2007 files

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -525,7 +525,12 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 								}
 
 								if ((int)$xf["numFmtId"] < 164) {
-									$numFmt = PHPExcel_Style_NumberFormat::builtInFormatCode((int)$xf["numFmtId"]);
+									$builtInFormat = PHPExcel_Style_NumberFormat::builtInFormatCode((int)$xf["numFmtId"]);
+
+									if ($builtInFormat) {
+										$numFmt = $builtInFormat;
+									}
+
 								}
 							}
                             $quotePrefix = false;


### PR DESCRIPTION
In Norwegian Excel2007 files the number format 43 (_ \* #,##0.00_ ;_ *
-#,##0.00_ ;_ \* "-"??_ ;_ @_ ) is standard for numbers with thousand
separators but not a part of the built in styles in PHPExcel.
