### PR TITLE
Calculation Confuses CellRef as NamedRange

### DIFF
--- a/Classes/PHPExcel/Calculation.php
+++ b/Classes/PHPExcel/Calculation.php
@@ -40,12 +40,12 @@ if (!defined('CALCULATION_REGEXP_CELLREF')) {
 	//	Test for support of \P (multibyte options) in PCRE
 	if(defined('PREG_BAD_UTF8_ERROR')) {
 		//	Cell reference (cell or range of cells, with or without a sheet reference)
-		define('CALCULATION_REGEXP_CELLREF','((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?([a-z]{1,3})\$?(\d{1,7})');
+        define('CALCULATION_REGEXP_CELLREF','((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?\b([a-z]{1,3})\$?(\d{1,7})(?![\w.])');
 		//	Named Range of cells
 		define('CALCULATION_REGEXP_NAMEDRANGE','((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?([_A-Z][_A-Z0-9\.]*)');
 	} else {
 		//	Cell reference (cell or range of cells, with or without a sheet reference)
-		define('CALCULATION_REGEXP_CELLREF','(((\w*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?([a-z]{1,3})\$?(\d+)');
+        define('CALCULATION_REGEXP_CELLREF','(((\w*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?\b([a-z]{1,3})\$?(\d+)(?![\w.])');
 		//	Named Range of cells
 		define('CALCULATION_REGEXP_NAMEDRANGE','(((\w*)|(\'.*\')|(\".*\"))!)?([_A-Z][_A-Z0-9\.]*)');
 	}


### PR DESCRIPTION
Regexps defining CellRef end prematurely. So a formula such as '=A1A'
matches A1 as a CellRef rather than A1A as a NamedRange, which
eventually causes engine to throw an exception.

First time using Git. Please let me know if I should have done something different.