### PR TITLE
Fix formula calculation, when referencing an empty cell in another sheet

### DIFF
--- a/Classes/PHPExcel/Calculation.php
+++ b/Classes/PHPExcel/Calculation.php
@@ -3338,13 +3338,13 @@ class PHPExcel_Calculation {
 									$cellValue = $this->extractCellRange($cellRef, $this->_workbook->getSheetByName($matches[2]), FALSE);
 									$pCell->attach($pCellParent);
 								} else {
+									$cellRef = $matches[2] . '!' . $cellRef;
 									$cellValue = NULL;
 								}
 							} else {
 								return $this->_raiseFormulaError('Unable to access Cell Reference');
 							}
 							$this->_debugLog->writeDebugLog('Evaluation Result for cell ', $cellRef, ' in worksheet ', $matches[2], ' is ', $this->_showTypeDetails($cellValue));
-//							$cellRef = $matches[2].'!'.$cellRef;
 						} else {
 //							echo '$cellRef='.$cellRef.' in current worksheet<br />';
 							$this->_debugLog->writeDebugLog('Evaluating Cell ', $cellRef, ' in current worksheet');


### PR DESCRIPTION
**Reason of changes:** $this->extractCellRange used above returns full reference, including the sheet name. So, if the cell was empty, we were losing the sheet reference in returned value.

**Example:** Workbook with two SpreadSheets
  Sheet1. A1: =SUM(Sheet2!B1:B3)
  Sheet2. B2: 3
**Expected result:** Sheet1!A1 = 3
**Effective result:** Sheet1!A1 = 0

**PHP snippet to test:**
https://github.com/pavel-koryagin/PHPExcel/wiki/Snippet-to-test-commit-%22Fix-formula-calculation,-when-referencing-an-empty-cell-in-another-sheet%22