### PR TITLE
Respecting plotVisibleOnly option

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -101,7 +101,7 @@ class PHPExcel_Writer_Excel2007_Chart extends
     $this->_writeLegend($pChart->getLegend(), $objWriter);
 
     $objWriter->startElement('c:plotVisOnly');
-    $objWriter->writeAttribute('val', 1);
+    $objWriter->writeAttribute('val', $pChart->getPlotVisibleOnly());
     $objWriter->endElement();
 
     $objWriter->startElement('c:dispBlanksAs');


### PR DESCRIPTION
This is simple one-liner which sets "c:plotVisOnly" tag value based on "plotVisibleOnly" argument when printing Excel2007 document. 

I experienced the problem with it while trying to generate a pie chart from hidden columns. After some investigation, I tracked down the "c:plotVisOnly" tag which was always stuck with value "1", independent of "plotVisibleOnly" argument passed to `Chart` constructor.