### PR TITLE
Allow insertion of user css styles for the HTML writer

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -76,6 +76,14 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 	 */
 	private $_cssStyles = null;
 
+        /**
+         * Array of user CSS styles
+         *
+         * @var array
+         */
+	private $_cssUserStyles = array();
+
+
 	/**
 	 * Array of column widths in points
 	 *
@@ -508,6 +516,13 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 		return $html;
 	}
 
+        /**
+         * Add user CSS styles.
+         */
+         public function addUserCssStyles($cssStyles) {
+                $this->_cssUserStyles += $cssStyles;
+        }
+
 	private function _extendRowsForChartsAndImages(PHPExcel_Worksheet $pSheet, $row) {
 		$rowMax = $row;
 		$colMax = 'A';
@@ -858,7 +873,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
 		// Cache
 		if (is_null($this->_cssStyles)) {
-			$this->_cssStyles = $css;
+			$this->_cssStyles = array_merge_recursive($css, $this->_cssUserStyles);
 		}
 
 		// Return


### PR DESCRIPTION
That is, add a addUserCssStyles() method to the HTML writer, usage:
```php
...
$objWriter = PHPExcel_IOFactory::createWriter($objPHPExcel, 'HTML');
$cssStyle = array();
$cssStyle['td.style0']['border'] = '1px solid red';
$objWriter->addUserCssStyles($cssStyle);
...
```
