### PR TITLE
Excel5/OLERead Infinite loop if size property corrupted.

### DIFF
--- a/Classes/PHPExcel/Shared/OLERead.php
+++ b/Classes/PHPExcel/Shared/OLERead.php
@@ -179,6 +179,13 @@ class PHPExcel_Shared_OLERead {
 		$streamData = '';
 
 		if ($this->props[$stream]['size'] < self::SMALL_BLOCK_THRESHOLD) {
+            $numBlocks = $this->props[$stream]['size'] / self::SMALL_BLOCK_SIZE;
+            if ($this->props[$stream]['size'] % self::SMALL_BLOCK_SIZE != 0) {
+                ++$numBlocks;
+            }
+
+            if ($numBlocks == 0) return '';
+
 			$rootdata = $this->_readData($this->props[$this->rootentry]['startBlock']);
 
 			$block = $this->props[$stream]['startBlock'];


### PR DESCRIPTION
When an excel file becomes corrupted/truncated such that the size property is miss read, OLEReader will go into an infinite loop.  

Steps to reproduce:

1) Truncate an xls file by around 260 bytes.
2) Attempt to load the file using the PHPExcel_Reader_Excel5->load() function.

Result:
 An infinite loop will occur in the OLEReader->getStream() function.

Potential solution (in this pull request):
Adding a check in get stream for the 'small block' code path that ensures that there are at least some blocks to read before continuing (similar to the big block code path)

Alternative solution:
Add a check in the 'canRead' method of the loaders that will look for the incorrect size property.

I have test code that can be used to reproduce this issue if needed.