### PR TITLE
add getTextRotation() functionality to HTML writer

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -741,7 +741,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 			// html { }
 			$css['html']['font-family']	  = 'Calibri, Arial, Helvetica, sans-serif';
 			$css['html']['font-size']		= '11pt';
-			$css['html']['background-color'] = 'white';
+			$css['html']['background-color'] = 'transparent';
 		}
 
 
@@ -897,6 +897,21 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 		// Construct CSS
 		$css = array();
 
+		//TextRotation
+		if ($textRotate = $pStyle->getTextRotation()) {
+		$css['mso-rotate'] = $textRotate;  				//MS Office
+		$css['-ms-transform'] = 'rotate(-'.$textRotate.'deg)';  	//IE9+
+		$css['-webkit-transform'] = 'rotate(-'.$textRotate.'deg)'; 	//Chrome, Safari
+		$css['-moz-transform'] = 'rotate(-'.$textRotate.'deg)'; 	//Firefox
+		$css['-o-transform'] = 'rotate(-'.$textRotate.'deg)';		//Opera
+		if ($textRotate == 90) $textRotate = 1;
+		elseif ($textRotate == 180) $textRotate = 2;
+		elseif ($textRotate == 270) $textRotate = 3;
+		else $textRotate = 0;
+		$css['-ms-filter'] = 'progid:DXImageTransform.Microsoft.BasicImage(rotation='.$textRotate.')'; //IE8
+		$css['filter'] = 'progid:DXImageTransform.Microsoft.BasicImage(rotation='.$textRotate.')'; //IE6-7
+		}
+
 		// Create CSS
 		$css['vertical-align'] = $this->_mapVAlign($pStyle->getVertical());
 		if ($textAlign = $this->_mapHAlign($pStyle->getHorizontal())) {
@@ -991,7 +1006,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
 		// Create CSS
 		$value = $pStyle->getFillType() == PHPExcel_Style_Fill::FILL_NONE ?
-			'white' : '#' . $pStyle->getStartColor()->getRGB();
+			'transparent' : '#' . $pStyle->getStartColor()->getRGB();
 		$css['background-color'] = $value;
 
 		// Return


### PR DESCRIPTION
If setTextRotation() was used, now html version write it too.

Default CSS 'background-color' settings changed to 'transparent' for correct rotation.