### PR TITLE
Update CacheBase.php to prevent fatal error

### DIFF
--- a/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
+++ b/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
@@ -151,7 +151,7 @@ abstract class PHPExcel_CachedObjectStorage_CacheBase {
      * @throws	PHPExcel_Exception
      */
 	public function deleteCacheData($pCoord) {
-		if ($pCoord === $this->_currentObjectID) {
+		if ($pCoord === $this->_currentObjectID && !is_null($this->_currentObject)) {
 			$this->_currentObject->detach();
 			$this->_currentObjectID = $this->_currentObject = null;
 		}


### PR DESCRIPTION
When deleteCacheData() is called it will throw a fatal error if the _currentObject is null.