### PR TITLE
Remove body from abstract function.

### DIFF
--- a/Classes/PHPExcel/Worksheet/CellIterator.php
+++ b/Classes/PHPExcel/Worksheet/CellIterator.php
@@ -79,8 +79,7 @@ abstract class PHPExcel_Worksheet_CellIterator
 	 *
      * @throws PHPExcel_Exception
 	 */
-    abstract protected function adjustForExistingOnlyRange() {
-    }
+    abstract protected function adjustForExistingOnlyRange();
 
 	/**
 	 * Set the iterator to loop only existing cells


### PR DESCRIPTION
Fixes error in latest release:

Abstract function PHPExcel_Worksheet_CellIterator::adjustForExistingOnlyRange() cannot contain body