### PR TITLE
Excel5: set default codepage

### DIFF
--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -578,7 +578,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {

--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -238,6 +238,8 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 	 */
 	private $_codepage;
 
+	private $_defaultCodepage = 'CP1252';
+
 	/**
 	 * Shared formats
 	 *
@@ -630,7 +632,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 		// initialize
 		$this->_pos					= 0;
-		$this->_codepage			= 'CP1252';
+		$this->_codepage			= $this->_defaultCodepage;
 		$this->_formats				= array();
 		$this->_objFonts			= array();
 		$this->_palette				= array();
@@ -1091,6 +1093,10 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		}
 
 		return $this->_phpExcel;
+	}
+
+	public function setDefaultCodepage($val) {
+		$this->_defaultCodepage = $val;
 	}
 	
 	/**


### PR DESCRIPTION
I have excel files without codepage set or with incorrect codepage and it falls back to CP1252 which is latin1.
I need it to fallback to different codepage (like cp1251), so I've made default codepage for Excel5 reader as a setting.