### PR TITLE
[Excel2007] [Conditional] - Add support for conditionally format duplicate values

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -921,7 +921,7 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
                             if (!$this->readDataOnly && $xmlSheet && $xmlSheet->conditionalFormatting) {
                                 foreach ($xmlSheet->conditionalFormatting as $conditional) {
                                     foreach ($conditional->cfRule as $cfRule) {
-                                        if (((string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_NONE || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_CELLIS || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_CONTAINSTEXT || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_EXPRESSION) && isset($dxfs[intval($cfRule["dxfId"])])) {
+                                        if (((string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_NONE || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_CELLIS || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_CONTAINSTEXT || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_EXPRESSION || (string)$cfRule["type"] == PHPExcel_Style_Conditional::CONDITION_DUPLICATEVALUES) && isset($dxfs[intval($cfRule["dxfId"])])) {
                                             $conditionals[(string) $conditional["sqref"]][intval($cfRule["priority"])] = $cfRule;
                                         }
                                     }

--- a/Classes/PHPExcel/Style/Conditional.php
+++ b/Classes/PHPExcel/Style/Conditional.php
@@ -36,10 +36,11 @@
 class PHPExcel_Style_Conditional implements PHPExcel_IComparable
 {
     /* Condition types */
-    const CONDITION_NONE         = 'none';
-    const CONDITION_CELLIS       = 'cellIs';
-    const CONDITION_CONTAINSTEXT = 'containsText';
-    const CONDITION_EXPRESSION   = 'expression';
+    const CONDITION_NONE            = 'none';
+    const CONDITION_CELLIS          = 'cellIs';
+    const CONDITION_CONTAINSTEXT    = 'containsText';
+    const CONDITION_EXPRESSION      = 'expression';
+    const CONDITION_DUPLICATEVALUES = 'duplicateValues';
 
     /* Operator types */
     const OPERATOR_NONE               = '';


### PR DESCRIPTION
This small patch adds support for conditional formatting duplicate values like Excel does:
![Image of Yaktocat](http://i.stack.imgur.com/xxuUL.png)

As Excel's condition rule for this just uses the type `duplicateValues` (e.g., `<cfRule type="duplicateValues" dxfId="0" priority="1" />`) this patch pretty small and easy.

I hope I could help with it.