### PR TITLE
don't calculate formulas if autosize is on and preCalculateFormulars …

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -705,7 +705,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
      * @param  boolean  $calculateMergeCells  Calculate merge cell width
      * @return PHPExcel_Worksheet;
      */
-    public function calculateColumnWidths($calculateMergeCells = false)
+    public function calculateColumnWidths($calculateMergeCells = false, $preCalculateFormulas = true)
     {
         // initialize $autoSizes array
         $autoSizes = array();
@@ -733,8 +733,9 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
                     if (!isset($isMergeCell[$this->cellCollection->getCurrentAddress()])) {
                         // Calculated value
                         // To formatted string
+			$value = $preCalculateFormulas ? $cell->getCalculatedValue() : $cell->getValue();
                         $cellValue = PHPExcel_Style_NumberFormat::toFormattedString(
-                            $cell->getCalculatedValue(),
+                            $value,
                             $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getNumberFormat()->getFormatCode()
                         );
 

--- a/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
@@ -375,7 +375,7 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
         if (count($pSheet->getColumnDimensions()) > 0) {
             $objWriter->startElement('cols');
 
-            $pSheet->calculateColumnWidths();
+            $pSheet->calculateColumnWidths(false, $this->getParentWriter()->getPreCalculateFormulas());
 
             // Loop through column dimensions
             foreach ($pSheet->getColumnDimensions() as $colDimension) {

--- a/Classes/PHPExcel/Writer/Excel5/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel5/Worksheet.php
@@ -285,7 +285,7 @@ class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
         $this->writeGridset();
 
         // Calculate column widths
-        $phpSheet->calculateColumnWidths();
+        $phpSheet->calculateColumnWidths(false, $this->getParentWriter()->getPreCalculateFormulas());
 
         // Column dimensions
         if (($defaultWidth = $phpSheet->getDefaultColumnDimension()->getWidth()) < 0) {


### PR DESCRIPTION
don't calculate formulas if autosize is on and preCalculateFormulars is off.

    $objPHPExcel = new PHPExcel();

    $objPHPExcel->getActiveSheet()->getColumnDimension('A')->setAutoSize(true);
    $objPHPExcel->getActiveSheet()->setCellValue('A1', 'testing')->setCellValue('B1', '=.=');

    $objWriter = PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
    $objWriter->save('/tmp/test.xlsx');

Call Stack
\#	Time	Memory	Function	Location
> 1	0.0009	300368	{main}( )	../02types.php:0
> 2	0.0549	6186240	PHPExcel_Writer_Excel2007->save( )	../02types.php:157
> 3	0.0614	6419800	PHPExcel_Writer_Excel2007_Worksheet->writeWorksheet( ) ../Excel2007.php:295
> 4	0.0615	6423456	PHPExcel_Writer_Excel2007_Worksheet->writeCols( )	../Worksheet.php:80
> 5	0.0615	6424008	PHPExcel_Worksheet->calculateColumnWidths( )	../Worksheet.php:378
> 6	0.0639	6594168	PHPExcel_Cell->getCalculatedValue( )	../Worksheet.php:737