### PR TITLE
Add default value for $contents in getFromName()

### DIFF
--- a/Classes/PHPExcel/Shared/ZipArchive.php
+++ b/Classes/PHPExcel/Shared/ZipArchive.php
@@ -123,8 +123,9 @@ class PHPExcel_Shared_ZipArchive
     /**
      * Extract file from archive by given fileName (Emulate ZipArchive getFromName())
      *
-     * @param        string        $fileName        Filename for the file in zip archive
-     * @return        string  $contents        File string contents
+     * @access  public
+     * @param   string  $fileName   Filename for the file in zip archive
+     * @return  string  $contents   File string contents
      */
     public function getFromName($fileName)
     {
@@ -154,6 +155,8 @@ class PHPExcel_Shared_ZipArchive
             }
             $extracted = $this->zip->extractByIndex($list_index, PCLZIP_OPT_EXTRACT_AS_STRING);
         }
+        
+        $contents = "";
         if ((is_array($extracted)) && ($extracted != 0)) {
             $contents = $extracted[0]["content"];
         }


### PR DESCRIPTION
PHP spit out a warning for an undefined variable `$contents` in the case where `$extracted` was empty, adding an empty string default value for `$contents` prevents this warning from showing up.