### PR TITLE
Changed disk cache default dir to system temp dir

### DIFF
--- a/Classes/PHPExcel/Writer/Abstract.php
+++ b/Classes/PHPExcel/Writer/Abstract.php
@@ -27,6 +27,7 @@
  */
 abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
 {
+
     /**
      * Write charts that are defined in the workbook?
      * Identifies whether the Writer should write definitions for any charts that exist in the PHPExcel object;
@@ -56,7 +57,7 @@ abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
      *
      * @var string
      */
-    protected $_diskCachingDirectory    = './';
+    protected $_diskCachingDirectory = './';
 
     /**
      * Write charts in workbook?
@@ -141,6 +142,8 @@ abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
             } else {
                 throw new PHPExcel_Writer_Exception("Directory does not exist: $pDirectory");
             }
+        } else {
+            $this->_diskCachingDirectory = PHPExcel_Shared_File::sys_get_temp_dir();
         }
         return $this;
     }
@@ -154,4 +157,5 @@ abstract class PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
     {
         return $this->_diskCachingDirectory;
     }
+
 }


### PR DESCRIPTION
Previously if you turned on disk caching and didn't specify a directory current working directory was used "./" (property default value). Which is not really a desired or expected behaviour as this value is optional. If left unset phpexcel tries to write temporary xml files to CWD of your application and fails if it is not writeable, which it should be in normal setup or creates many temporary xml files in your root.