### PR TITLE
Deleted $_preCalculateFormulas override

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007.php
+++ b/Classes/PHPExcel/Writer/Excel2007.php
@@ -28,17 +28,6 @@
 class PHPExcel_Writer_Excel2007 extends PHPExcel_Writer_Abstract implements PHPExcel_Writer_IWriter
 {
     /**
-     * Pre-calculate formulas
-     * Forces PHPExcel to recalculate all formulae in a workbook when saving, so that the pre-calculated values are
-     *    immediately available to MS Excel or other office spreadsheet viewer when opening the file
-     *
-     * Overrides the default TRUE for this specific writer for performance reasons
-     *
-     * @var boolean
-     */
-    protected $preCalculateFormulas = false;
-
-    /**
      * Office2003 compatibility
      *
      * @var boolean


### PR DESCRIPTION
Deleted the pre-calculate formulas override to avoid formulae problem with LibreOffice and OpenOffice ( #433 ).