### PR TITLE
Update LookupRef.php

### DIFF
--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -555,7 +555,7 @@ class PHPExcel_Calculation_LookupRef
             if (($match_type == 0) && ($lookupArrayValue == $lookup_value)) {
                 //    exact match
                 return ++$i;
-            } elseif (($match_type == -1) && ($lookupArrayValue <= $lookup_value)) {
+            } elseif (($match_type == -1) && ($lookupArrayValue < $lookup_value)) {
                 $i = array_search($i, $keySet);
                 // if match_type is -1 <=> find the smallest value that is greater than or equal to lookup_value
                 if ($i < 1) {
@@ -565,7 +565,7 @@ class PHPExcel_Calculation_LookupRef
                     // the previous cell was the match
                     return $keySet[$i-1]+1;
                 }
-            } elseif (($match_type == 1) && ($lookupArrayValue >= $lookup_value)) {
+            } elseif (($match_type == 1) && ($lookupArrayValue > $lookup_value)) {
                 $i = array_search($i, $keySet);
                 // if match_type is 1 <=> find the largest value that is less than or equal to lookup_value
                 if ($i < 1) {


### PR DESCRIPTION
Hi,
thank you for this great project!

I may have found a tiny bug in the adaption of Excels match function. Got some deviation on some functions today.
Cause the match_types 1 and -1s meaning is also 'or equal' i guess the match has to be pure < or >.
Could you take al look at - some simple comparisons where ok afterwards.
The $keySet[$i-1]+1 is ok if to percept -1 as the row before and +1 as correction of index-disparity.

best regards,
sören