### PR TITLE
Fixed hidden columns for Chome

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -847,16 +847,17 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
             // col elements, loop through columnDimensions and set width
             foreach ($sheet->getColumnDimensions() as $columnDimension) {
+                $column = PHPExcel_Cell::columnIndexFromString($columnDimension->getColumnIndex()) - 1;
                 if (($width = PHPExcel_Shared_Drawing::cellDimensionToPixels($columnDimension->getWidth(), $this->defaultFont)) >= 0) {
                     $width = PHPExcel_Shared_Drawing::pixelsToPoints($width);
-                    $column = PHPExcel_Cell::columnIndexFromString($columnDimension->getColumnIndex()) - 1;
                     $this->columnWidths[$sheetIndex][$column] = $width;
                     $css['table.sheet' . $sheetIndex . ' col.col' . $column]['width'] = $width . 'pt';
-
-                    if ($columnDimension->getVisible() === false) {
-                        $css['table.sheet' . $sheetIndex . ' col.col' . $column]['visibility'] = 'collapse';
-                        $css['table.sheet' . $sheetIndex . ' col.col' . $column]['*display'] = 'none'; // target IE6+7
-                    }
+                }
+                
+                if ($columnDimension->getVisible() === false) {
+                    $css['table.sheet' . $sheetIndex . ' col.col' . $column]['visibility'] = 'collapse';
+                    $css['table.sheet' . $sheetIndex . ' .column' . $column]['display'] = 'none'; // target Chrome
+                    $css['table.sheet' . $sheetIndex . ' col.col' . $column]['*display'] = 'none'; // target IE6+7
                 }
             }
 


### PR DESCRIPTION
Hidden columns were working only for columns with set width. I moved it outside of "if" so these two things are not connected now..

Also it was not working in Chrome at all because of this bug -> https://code.google.com/p/chromium/issues/detail?id=174167
Chrome doesn't support visibility:collapse and in fact any kid of visibility for "col" tag.

Maybe there is better workout than display:none on .column class but I haven't found one.

$css['table.sheet' . $sheetIndex . '  col.col' . $column]['display'] = 'none' is not working in Chrome