### PR TITLE
Semantic table HTML reader

### DIFF
--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -189,6 +189,10 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
         $this->sheet = $objPHPExcel->getActiveSheet();
     }
 
+    protected function finishHandler()
+    {
+    }
+
     protected function flushCell($column, $row, &$cellContent)
     {
         if (is_string($cellContent)) {

--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -12,6 +12,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  * PHPExcel_Reader_HTML
  *
  * Copyright (c) 2006 - 2015 PHPExcel
+ * Copyright (c) 2015 Wine Logistix GmbH
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,6 +31,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  * @category   PHPExcel
  * @package    PHPExcel_Reader
  * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2015 Wine Logistix GmbH (http://www.wine-logistix.de)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -97,16 +99,16 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
             'font' => array(
                 'underline' => true,
                 'color' => array(
-                    'argb' => PHPExcel_Style_Color::COLOR_BLUE,
+                    'argb' => \PHPExcel_Style_Color::COLOR_BLUE,
                 ),
             ),
         ), //    Blue underlined
         'hr' => array(
             'borders' => array(
                 'bottom' => array(
-                    'style' => PHPExcel_Style_Border::BORDER_THIN,
+                    'style' => \PHPExcel_Style_Border::BORDER_THIN,
                     'color' => array(
-                        PHPExcel_Style_Color::COLOR_BLACK,
+                        \PHPExcel_Style_Color::COLOR_BLACK,
                     ),
                 ),
             ),
@@ -120,7 +122,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
      */
     public function __construct()
     {
-        $this->readFilter = new PHPExcel_Reader_DefaultReadFilter();
+        $this->readFilter = new \PHPExcel_Reader_DefaultReadFilter();
     }
 
     /**
@@ -225,7 +227,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
         }
     }
 
-    protected function defaultElementHandler(DOMNode $element, &$row, &$column, &$cellContent, $format = null)
+    protected function defaultElementHandler(\DOMNode $element, &$row, &$column, &$cellContent, $format = null)
     {
 //                echo '<b>DOM ELEMENT: </b>' , strtoupper($element->nodeName) , '<br />';
 

--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -444,6 +444,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
                     default:
                         $this->processDomElement($element, $row, $column, $cellContent);
                 }
+                // This method does all traversing itself, no TRAVERSE_CHILD hint needed.
     }
 
     /**

--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -34,7 +34,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  * @version    ##VERSION##, ##DATE##
  */
 /** PHPExcel root directory */
-class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_Reader_IReader
+class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
 {
 
     /**
@@ -124,39 +124,6 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
     }
 
     /**
-     * Validate that the current file is an HTML file
-     *
-     * @return boolean
-     */
-    protected function isValidFormat()
-    {
-        //    Reading 2048 bytes should be enough to validate that the format is HTML
-        $data = fread($this->fileHandle, 2048);
-        if ((strpos($data, '<') !== false) &&
-                (strlen($data) !== strlen(strip_tags($data)))) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Loads PHPExcel from file
-     *
-     * @param  string                    $pFilename
-     * @return PHPExcel
-     * @throws PHPExcel_Reader_Exception
-     */
-    public function load($pFilename)
-    {
-        // Create new PHPExcel
-        $objPHPExcel = new PHPExcel();
-
-        // Load into this instance
-        return $this->loadIntoExisting($pFilename, $objPHPExcel);
-    }
-
-    /**
      * Set input encoding
      *
      * @param string $pValue Input encoding
@@ -183,6 +150,12 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
     protected $tableLevel = 0;
     protected $nestedColumn = array('A');
 
+    /**
+     * Active Worksheet which is used for writing to.
+     * @var \PHPExcel_Worksheet
+     */
+    protected $sheet;
+
     protected function setTableStartColumn($column)
     {
         if ($this->tableLevel == 0) {
@@ -206,7 +179,17 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
         return array_pop($this->nestedColumn);
     }
 
-    protected function flushCell($sheet, $column, $row, &$cellContent)
+    protected function loadHandler(\PHPExcel $objPHPExcel)
+    {
+        // Create new PHPExcel worksheets.
+        while ($objPHPExcel->getSheetCount() <= $this->sheetIndex) {
+            $objPHPExcel->createSheet();
+        }
+        $objPHPExcel->setActiveSheetIndex($this->sheetIndex);
+        $this->sheet = $objPHPExcel->getActiveSheet();
+    }
+
+    protected function flushCell($column, $row, &$cellContent)
     {
         if (is_string($cellContent)) {
             //    Simple String content
@@ -215,7 +198,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
 //                echo 'FLUSH CELL: ' , $column , $row , ' => ' , $cellContent , '<br />';
                 //    Write to worksheet to be done here...
                 //    ... we return the cell so we can mess about with styles more easily
-                $sheet->setCellValue($column . $row, $cellContent, true);
+                $this->sheet->setCellValue($column . $row, $cellContent, true);
                 $this->dataArray[$row][$column] = $cellContent;
             }
         } else {
@@ -226,28 +209,29 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
         $cellContent = (string) '';
     }
 
-    protected function processDomElement(DOMNode $element, $sheet, &$row, &$column, &$cellContent, $format = null)
+    protected function textElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
     {
-        foreach ($element->childNodes as $child) {
-            if ($child instanceof DOMText) {
-                $domText = preg_replace('/\s+/u', ' ', trim($child->nodeValue));
-                if (is_string($cellContent)) {
-                    //    simply append the text if the cell content is a plain text string
-                    $cellContent .= $domText;
-                } else {
-                    //    but if we have a rich text run instead, we need to append it correctly
-                    //    TODO
-                }
-            } elseif ($child instanceof DOMElement) {
-//                echo '<b>DOM ELEMENT: </b>' , strtoupper($child->nodeName) , '<br />';
+        $domText = preg_replace('/\s+/u', ' ', trim($element->nodeValue));
+        if (is_string($cellContent)) {
+            //    simply append the text if the cell content is a plain text string
+            $cellContent .= $domText;
+        } else {
+            //    but if we have a rich text run instead, we need to append it correctly
+            //    TODO
+        }
+    }
+
+    protected function defaultElementHandler(DOMNode $element, &$row, &$column, &$cellContent, $format = null)
+    {
+//                echo '<b>DOM ELEMENT: </b>' , strtoupper($element->nodeName) , '<br />';
 
                 $attributeArray = array();
-                foreach ($child->attributes as $attribute) {
+                foreach ($element->attributes as $attribute) {
 //                    echo '<b>ATTRIBUTE: </b>' , $attribute->name , ' => ' , $attribute->value , '<br />';
                     $attributeArray[$attribute->name] = $attribute->value;
                 }
 
-                switch ($child->nodeName) {
+                switch ($element->nodeName) {
                     case 'meta':
                         foreach ($attributeArray as $attributeName => $attributeValue) {
                             switch ($attributeName) {
@@ -257,11 +241,11 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                                     break;
                             }
                         }
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                         break;
                     case 'title':
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
-                        $sheet->setTitle($cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
+                        $this->sheet->setTitle($cellContent);
                         $cellContent = '';
                         break;
                     case 'span':
@@ -275,20 +259,20 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                         if ($cellContent > '') {
                             $cellContent .= ' ';
                         }
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                         if ($cellContent > '') {
                             $cellContent .= ' ';
                         }
 //                        echo 'END OF STYLING, SPAN OR DIV<br />';
                         break;
                     case 'hr':
-                        $this->flushCell($sheet, $column, $row, $cellContent);
+                        $this->flushCell($column, $row, $cellContent);
                         ++$row;
-                        if (isset($this->formats[$child->nodeName])) {
-                            $sheet->getStyle($column . $row)->applyFromArray($this->formats[$child->nodeName]);
+                        if (isset($this->formats[$element->nodeName])) {
+                            $this->sheet->getStyle($column . $row)->applyFromArray($this->formats[$element->nodeName]);
                         } else {
                             $cellContent = '----------';
-                            $this->flushCell($sheet, $column, $row, $cellContent);
+                            $this->flushCell($column, $row, $cellContent);
                         }
                         ++$row;
                         // Add a break after a horizontal rule, simply by allowing the code to dropthru
@@ -298,7 +282,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             $cellContent .= "\n";
                         } else {
                             //    Otherwise flush our existing content and move the row cursor on
-                            $this->flushCell($sheet, $column, $row, $cellContent);
+                            $this->flushCell($column, $row, $cellContent);
                             ++$row;
                         }
 //                        echo 'HARD LINE BREAK: ' , '<br />';
@@ -309,15 +293,15 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             switch ($attributeName) {
                                 case 'href':
 //                                    echo 'Link to ' , $attributeValue , '<br />';
-                                    $sheet->getCell($column . $row)->getHyperlink()->setUrl($attributeValue);
-                                    if (isset($this->formats[$child->nodeName])) {
-                                        $sheet->getStyle($column . $row)->applyFromArray($this->formats[$child->nodeName]);
+                                    $this->sheet->getCell($column . $row)->getHyperlink()->setUrl($attributeValue);
+                                    if (isset($this->formats[$element->nodeName])) {
+                                        $this->sheet->getStyle($column . $row)->applyFromArray($this->formats[$element->nodeName]);
                                     }
                                     break;
                             }
                         }
                         $cellContent .= ' ';
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
 //                        echo 'END OF HYPERLINK:' , '<br />';
                         break;
                     case 'h1':
@@ -333,20 +317,20 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             //    If we're inside a table, replace with a \n
                             $cellContent .= "\n";
 //                            echo 'LIST ENTRY: ' , '<br />';
-                            $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                            $this->processDomElement($element, $row, $column, $cellContent);
 //                            echo 'END OF LIST ENTRY:' , '<br />';
                         } else {
                             if ($cellContent > '') {
-                                $this->flushCell($sheet, $column, $row, $cellContent);
+                                $this->flushCell($column, $row, $cellContent);
                                 $row++;
                             }
 //                            echo 'START OF PARAGRAPH: ' , '<br />';
-                            $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                            $this->processDomElement($element, $row, $column, $cellContent);
 //                            echo 'END OF PARAGRAPH:' , '<br />';
-                            $this->flushCell($sheet, $column, $row, $cellContent);
+                            $this->flushCell($column, $row, $cellContent);
 
-                            if (isset($this->formats[$child->nodeName])) {
-                                $sheet->getStyle($column . $row)->applyFromArray($this->formats[$child->nodeName]);
+                            if (isset($this->formats[$element->nodeName])) {
+                                $this->sheet->getStyle($column . $row)->applyFromArray($this->formats[$element->nodeName]);
                             }
 
                             $row++;
@@ -358,28 +342,28 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             //    If we're inside a table, replace with a \n
                             $cellContent .= "\n";
 //                            echo 'LIST ENTRY: ' , '<br />';
-                            $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                            $this->processDomElement($element, $row, $column, $cellContent);
 //                            echo 'END OF LIST ENTRY:' , '<br />';
                         } else {
                             if ($cellContent > '') {
-                                $this->flushCell($sheet, $column, $row, $cellContent);
+                                $this->flushCell($column, $row, $cellContent);
                             }
                             ++$row;
 //                            echo 'LIST ENTRY: ' , '<br />';
-                            $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                            $this->processDomElement($element, $row, $column, $cellContent);
 //                            echo 'END OF LIST ENTRY:' , '<br />';
-                            $this->flushCell($sheet, $column, $row, $cellContent);
+                            $this->flushCell($column, $row, $cellContent);
                             $column = 'A';
                         }
                         break;
                     case 'table':
-                        $this->flushCell($sheet, $column, $row, $cellContent);
+                        $this->flushCell($column, $row, $cellContent);
                         $column = $this->setTableStartColumn($column);
 //                        echo 'START OF TABLE LEVEL ' , $this->tableLevel , '<br />';
                         if ($this->tableLevel > 1) {
                             --$row;
                         }
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
 //                        echo 'END OF TABLE LEVEL ' , $this->tableLevel , '<br />';
                         $column = $this->releaseTableStartColumn();
                         if ($this->tableLevel > 1) {
@@ -390,33 +374,33 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                         break;
                     case 'thead':
                     case 'tbody':
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                         break;
                     case 'tr':
                         $column = $this->getTableStartColumn();
                         $cellContent = '';
 //                        echo 'START OF TABLE ' , $this->tableLevel , ' ROW<br />';
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                         ++$row;
 //                        echo 'END OF TABLE ' , $this->tableLevel , ' ROW<br />';
                         break;
                     case 'th':
                     case 'td':
 //                        echo 'START OF TABLE ' , $this->tableLevel , ' CELL<br />';
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
 //                        echo 'END OF TABLE ' , $this->tableLevel , ' CELL<br />';
 
                         while (isset($this->rowspan[$column . $row])) {
                             ++$column;
                         }
 
-                        $this->flushCell($sheet, $column, $row, $cellContent);
+                        $this->flushCell($column, $row, $cellContent);
 
 //                        if (isset($attributeArray['style']) && !empty($attributeArray['style'])) {
 //                            $styleAry = $this->getPhpExcelStyleArray($attributeArray['style']);
 //
 //                            if (!empty($styleAry)) {
-//                                $sheet->getStyle($column . $row)->applyFromArray($styleAry);
+//                                $this->sheet->getStyle($column . $row)->applyFromArray($styleAry);
 //                            }
 //                        }
 
@@ -430,7 +414,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             foreach (\PHPExcel_Cell::extractAllCellReferencesInRange($range) as $value) {
                                 $this->rowspan[$value] = true;
                             }
-                            $sheet->mergeCells($range);
+                            $this->sheet->mergeCells($range);
                             $column = $columnTo;
                         } elseif (isset($attributeArray['rowspan'])) {
                             //create merging rowspan
@@ -438,14 +422,14 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                             foreach (\PHPExcel_Cell::extractAllCellReferencesInRange($range) as $value) {
                                 $this->rowspan[$value] = true;
                             }
-                            $sheet->mergeCells($range);
+                            $this->sheet->mergeCells($range);
                         } elseif (isset($attributeArray['colspan'])) {
                             //create merging colspan
                             $columnTo = $column;
                             for ($i = 0; $i < $attributeArray['colspan'] - 1; $i++) {
                                 ++$columnTo;
                             }
-                            $sheet->mergeCells($column . $row . ':' . $columnTo . $row);
+                            $this->sheet->mergeCells($column . $row . ':' . $columnTo . $row);
                             $column = $columnTo;
                         }
                         ++$column;
@@ -455,58 +439,11 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
                         $column = 'A';
                         $content = '';
                         $this->tableLevel = 0;
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                         break;
                     default:
-                        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
+                        $this->processDomElement($element, $row, $column, $cellContent);
                 }
-            }
-        }
-    }
-
-    /**
-     * Loads PHPExcel from file into PHPExcel instance
-     *
-     * @param  string                    $pFilename
-     * @param  PHPExcel                  $objPHPExcel
-     * @return PHPExcel
-     * @throws PHPExcel_Reader_Exception
-     */
-    public function loadIntoExisting($pFilename, PHPExcel $objPHPExcel)
-    {
-        // Open file to validate
-        $this->openFile($pFilename);
-        if (!$this->isValidFormat()) {
-            fclose($this->fileHandle);
-            throw new PHPExcel_Reader_Exception($pFilename . " is an Invalid HTML file.");
-        }
-        //    Close after validating
-        fclose($this->fileHandle);
-
-        // Create new PHPExcel
-        while ($objPHPExcel->getSheetCount() <= $this->sheetIndex) {
-            $objPHPExcel->createSheet();
-        }
-        $objPHPExcel->setActiveSheetIndex($this->sheetIndex);
-
-        //    Create a new DOM object
-        $dom = new domDocument;
-        //    Reload the HTML file into the DOM object
-        $loaded = $dom->loadHTML($this->securityScanFile($pFilename));
-        if ($loaded === false) {
-            throw new PHPExcel_Reader_Exception('Failed to load ', $pFilename, ' as a DOM Document');
-        }
-
-        //    Discard white space
-        $dom->preserveWhiteSpace = false;
-
-        $row = 0;
-        $column = 'A';
-        $content = '';
-        $this->processDomElement($dom, $objPHPExcel->getActiveSheet(), $row, $column, $content);
-
-        // Return
-        return $objPHPExcel;
     }
 
     /**
@@ -546,4 +483,6 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
         }
         return $xml;
     }
+
+
 }

--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -474,20 +474,5 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_HTML_Abstract
         return $this;
     }
 
-    /**
-     * Scan theXML for use of <!ENTITY to prevent XXE/XEE attacks
-     *
-     * @param     string         $xml
-     * @throws PHPExcel_Reader_Exception
-     */
-    public function securityScan($xml)
-    {
-        $pattern = '/\\0?' . implode('\\0?', str_split('<!ENTITY')) . '\\0?/';
-        if (preg_match($pattern, $xml)) {
-            throw new PHPExcel_Reader_Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
-        }
-        return $xml;
-    }
-
 
 }

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -41,11 +41,11 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
 
     /**
      * Write cell content at specified position to active sheet.
-     * @param int $row
      * @param string $column
+     * @param int $row
      * @param string $cellContent
      */
-    protected abstract function flushCell($row, $column, &$cellContent);
+    protected abstract function flushCell($column, $row, &$cellContent);
 
     /**
      * Handler for elements with no explicit handler.

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * PHPExcel_Reader_HTML
+ *
+ * Generic reader of HTML files which sub classes can extend
+ * to read HTML files to their need.
+ *
+ * Copyright (c) 2006 - 2015 PHPExcel
+ * Copyright (c) 2015 Wine Logistix GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category   PHPExcel
+ * @package    PHPExcel_Reader_HTML
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2015 Wine Logistix (http://www.wine-logistix.de)
+ * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
+ * @version    ##VERSION##, ##DATE##
+ */
+abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract implements PHPExcel_Reader_IReader
+{
+
+    /**
+     * Write cell content at specified position to active sheet.
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected abstract function flushCell($row, $column, &$cellContent);
+
+    /**
+     * Handler for elements with no explicit handler.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected abstract function defaultElementHandler(\DOMNode $element, &$row, &$column, &$cellContent);
+
+    /**
+     * Handler for DOMText elements.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected abstract function textElementHandler(\DOMNode $element, &$row, &$column, &$cellContent);
+
+    /**
+     * Handler which is executed after loading the HTML file and before
+     * traversing elements.
+     * @param \PHPExcel $objPHPExcel
+     */
+    protected abstract function loadHandler(\PHPExcel $objPHPExcel);
+
+    /**
+     * Loads PHPExcel from file.
+     * @param  string $pFilename
+     * @return PHPExcel
+     * @throws PHPExcel_Reader_Exception
+     */
+    public function load($pFilename)
+    {
+        // Create new PHPExcel
+        $objPHPExcel = new PHPExcel();
+        // Load into this instance
+        return $this->loadIntoExisting($pFilename, $objPHPExcel);
+    }
+
+    /**
+     * Loads PHPExcel from file into PHPExcel instance.
+     *
+     * @param  string                    $pFilename
+     * @param  PHPExcel                  $objPHPExcel
+     * @return PHPExcel
+     * @throws PHPExcel_Reader_Exception
+     */
+    public function loadIntoExisting($pFilename, PHPExcel $objPHPExcel)
+    {
+        // Open file to validate
+        $this->openFile($pFilename);
+        if (!$this->isValidFormat()) {
+            fclose($this->fileHandle);
+            throw new PHPExcel_Reader_Exception($pFilename . " is an invalid HTML file.");
+        }
+        //    Close after validating
+        fclose($this->fileHandle);
+
+        //    Create a new DOM object
+        $dom = new DOMDocument();
+        //    Reload the HTML file into the DOM object
+        $loaded = $dom->loadHTML($this->securityScanFile($pFilename));
+        if ($loaded === false) {
+            throw new PHPExcel_Reader_Exception('Failed to load ', $pFilename, ' as a DOM Document');
+        }
+
+        //    Discard white space
+        $dom->preserveWhiteSpace = false;
+
+        $row = 0;
+        $column = 'A';
+        $content = '';
+
+        // Allow implementation specific initalization after load.
+        $this->loadHandler($objPHPExcel);
+
+        $this->processDomElement($dom, $row, $column, $content);
+
+        // Return
+        return $objPHPExcel;
+    }
+
+    /**
+     * Validate that the current file is an HTML file
+     *
+     * @return boolean
+     */
+    protected function isValidFormat()
+    {
+        //    Reading 2048 bytes should be enough to validate that the format is HTML
+        $data = fread($this->fileHandle, 2048);
+        if ((strpos($data, '<') !== false) &&
+                (strlen($data) !== strlen(strip_tags($data)))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function processDomElement(DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof \DOMText) {
+                $this->textElementHandler($child, $row, $column, $cellContent);
+            } elseif ($child instanceof \DOMElement) {
+                // For each element a handler is invoked dynamically. If you don't want to use
+                // dynamic dispatch, use defaultElementHandler.
+                $nodeName = $this->cleanNodeName($child->nodeName);
+                $handlerName = $nodeName . "ElementHandler";
+                if (method_exists($this, $handlerName)) {
+                    $this->{$handlerName}($child, $row, $column, $cellContent);
+                } else {
+                    $this->defaultElementHandler($child, $row, $column, $cellContent);
+                }
+            }
+        }
+    }
+
+    protected function cleanNodeName($elementName)
+    {
+        return strtolower(preg_replace('/[^a-zA-Z0-9]/u', '', $elementName));
+    }
+}

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -195,4 +195,19 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
     {
         return strtolower(preg_replace('/[^a-zA-Z0-9]/u', '', $elementName));
     }
+
+    /**
+     * Scan theXML for use of <!ENTITY to prevent XXE/XEE attacks
+     *
+     * @param     string         $xml
+     * @throws PHPExcel_Reader_Exception
+     */
+    public function securityScan($xml)
+    {
+        $pattern = '/\\0?' . implode('\\0?', str_split('<!ENTITY')) . '\\0?/';
+        if (preg_match($pattern, $xml)) {
+            throw new PHPExcel_Reader_Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
+        }
+        return $xml;
+    }
 }

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -74,6 +74,12 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
     protected abstract function loadHandler(\PHPExcel $objPHPExcel);
 
     /**
+     * Handler which is executed after traversing elements and before
+     * returning from load method.
+     */
+    protected abstract function finishHandler();
+
+    /**
      * Loads PHPExcel from file.
      * @param  string $pFilename
      * @return PHPExcel
@@ -125,6 +131,9 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
         $this->loadHandler($objPHPExcel);
 
         $this->processDomElement($dom, $row, $column, $content);
+
+        // Allow implementation specific operation after processing.
+        $this->finishHandler();
 
         // Return
         return $objPHPExcel;

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -117,7 +117,7 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
         //    Discard white space
         $dom->preserveWhiteSpace = false;
 
-        $row = 0;
+        $row = 1;
         $column = 'A';
         $content = '';
 

--- a/Classes/PHPExcel/Reader/HTML/Abstract.php
+++ b/Classes/PHPExcel/Reader/HTML/Abstract.php
@@ -1,10 +1,23 @@
 <?php
 
 /**
- * PHPExcel_Reader_HTML
+ * PHPExcel_Reader_HTML_Abstract
  *
  * Generic reader of HTML files which sub classes can extend
  * to read HTML files to their need.
+ *
+ * When loading a document, the DOM is traversed with its top-level elements.
+ * A handler is invoked for each element. By default it is defaultElementHandler,
+ * though explicit handlers may be defined in the subclass in form
+ * <element_name>ElementHandler where <element_name> is lowercase element name.
+ * Explicit handlers must accept same arguments as defaultElementHandler.
+ *
+ * Other handlers exist which facilitate implementation specific behavior:
+ *
+ * flushCell - Write a cell value
+ * textElementHandler - Invoked for DOMText elements.
+ * loadHandler - Invoked before traversing the DOM.
+ * finishHandler - Invoked after traversing the DOM.
  *
  * Copyright (c) 2006 - 2015 PHPExcel
  * Copyright (c) 2015 Wine Logistix GmbH
@@ -34,7 +47,8 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
 {
 
     /**
-     * Tell processDomElement to traverse child elements of the current element recursively.
+     * Tell processDomElement to traverse child elements of the current child
+     * element recursively.
      * @var int
      */
     const TRAVERSE_CHILDS = 1;
@@ -53,7 +67,7 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
      * @param int $row
      * @param string $column
      * @param string $cellContent
-     * @return int TRAVERSE_CHILDS or null
+     * @return int|null TRAVERSE_CHILDS or null
      */
     protected abstract function defaultElementHandler(\DOMNode $element, &$row, &$column, &$cellContent);
 
@@ -88,7 +102,7 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
     public function load($pFilename)
     {
         // Create new PHPExcel
-        $objPHPExcel = new PHPExcel();
+        $objPHPExcel = new \PHPExcel();
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $objPHPExcel);
     }
@@ -101,23 +115,23 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
      * @return PHPExcel
      * @throws PHPExcel_Reader_Exception
      */
-    public function loadIntoExisting($pFilename, PHPExcel $objPHPExcel)
+    public function loadIntoExisting($pFilename, \PHPExcel $objPHPExcel)
     {
         // Open file to validate
         $this->openFile($pFilename);
         if (!$this->isValidFormat()) {
             fclose($this->fileHandle);
-            throw new PHPExcel_Reader_Exception($pFilename . " is an invalid HTML file.");
+            throw new \PHPExcel_Reader_Exception($pFilename . " is an invalid HTML file.");
         }
         //    Close after validating
         fclose($this->fileHandle);
 
         //    Create a new DOM object
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         //    Reload the HTML file into the DOM object
         $loaded = $dom->loadHTML($this->securityScanFile($pFilename));
         if ($loaded === false) {
-            throw new PHPExcel_Reader_Exception('Failed to load ', $pFilename, ' as a DOM Document');
+            throw new \PHPExcel_Reader_Exception('Failed to load ', $pFilename, ' as a DOM Document');
         }
 
         //    Discard white space
@@ -167,7 +181,7 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
      * @param string $column Excel style column name
      * @param $cellContent A buffer which can be used by implementation to store temporary cell content before flushing to cell.
      */
-    protected function processDomElement(DOMNode $element, &$row, &$column, &$cellContent)
+    protected function processDomElement(\DOMNode $element, &$row, &$column, &$cellContent)
     {
         foreach ($element->childNodes as $child) {
             if ($child instanceof \DOMText) {
@@ -206,7 +220,7 @@ abstract class PHPExcel_Reader_HTML_Abstract extends PHPExcel_Reader_Abstract im
     {
         $pattern = '/\\0?' . implode('\\0?', str_split('<!ENTITY')) . '\\0?/';
         if (preg_match($pattern, $xml)) {
-            throw new PHPExcel_Reader_Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
+            throw new \PHPExcel_Reader_Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
         }
         return $xml;
     }

--- a/Classes/PHPExcel/Reader/HTML/SemanticTable.php
+++ b/Classes/PHPExcel/Reader/HTML/SemanticTable.php
@@ -1,4 +1,13 @@
 <?php
+
+if (!defined('PHPEXCEL_ROOT')) {
+    /**
+     * @ignore
+     */
+    define('PHPEXCEL_ROOT', dirname(__FILE__) . '/../../../');
+    require(PHPEXCEL_ROOT . 'PHPExcel/Autoloader.php');
+}
+
 /**
  * PHPExcel_Reader_HTML_SemanticTable
  *
@@ -29,7 +38,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category   PHPExcel
- * @package    PHPExcel_Reader_HTML_SemanticTable
+ * @package    PHPExcel_Reader_HTML
  * @copyright  Copyright (c) 2015 Wine Logistix (http://www.wine-logistix.de)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
@@ -135,7 +144,7 @@ class PHPExcel_Reader_HTML_SemanticTable extends PHPExcel_Reader_HTML_Abstract
         // Row and column need to be reset.
         $row = 1;
         $column = 'A';
-        return PHPExcel_Reader_HTML_Abstract::TRAVERSE_CHILDS;
+        return \PHPExcel_Reader_HTML_Abstract::TRAVERSE_CHILDS;
     }
 
     /**

--- a/Classes/PHPExcel/Reader/HTML/SemanticTable.php
+++ b/Classes/PHPExcel/Reader/HTML/SemanticTable.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * PHPExcel_Reader_HTML_SemanticTable
+ *
+ * Parse each table element in HTML documents as a worksheet and honor
+ * semantic markup.
+ *
+ * The elements are treated as:
+ * title - Document title
+ * table - worksheet
+ * table > caption - worksheet title
+ * table > thead - Header rows (formatted bold)
+ * table > tbody - Data rows (no formatting)
+ *
+ * Copyright (c) 2015 Wine Logistix GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category   PHPExcel
+ * @package    PHPExcel_Reader_HTML_SemanticTable
+ * @copyright  Copyright (c) 2015 Wine Logistix (http://www.wine-logistix.de)
+ * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
+ * @version    ##VERSION##, ##DATE##
+ */
+class PHPExcel_Reader_HTML_SemanticTable extends PHPExcel_Reader_HTML_Abstract
+{
+
+    /**
+     * @var \PHPExcel
+     */
+    protected $excel;
+
+    /**
+     * Write cell content at specified position to active sheet.
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function flushCell($column, $row, &$cellContent)
+    {
+        if (is_string($cellContent)) {
+            $cellContent = trim($cellContent);
+            if ($cellContent !== '') {
+                $this->excel->getActiveSheet()->setCellValue($column.$row, $cellContent);
+            }
+        }
+    }
+
+    /**
+     * Handler for elements with no explicit handler.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function defaultElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        // This implementation doesn't care about any element except the ones
+        // for which an explicit handler is defined. To get to these elements
+        // though, children of the other elements need to be traversed.
+        return \PHPExcel_Reader_HTML_Abstract::TRAVERSE_CHILDS;
+    }
+
+    /**
+     * Handler for DOMText elements.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function textElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+    }
+
+    /**
+     * Handler which is executed after loading the HTML file and before
+     * traversing elements.
+     * @param \PHPExcel $objPHPExcel
+     */
+    protected function loadHandler(\PHPExcel $objPHPExcel)
+    {
+        $this->excel = $objPHPExcel;
+        // Remove first sheet because if no table elements are occured
+        // in document, then it's an error in the source file.
+        $this->excel->removeSheetByIndex(0);
+    }
+
+    protected function finishHandler()
+    {
+        if ($this->excel->getSheetCount() > 0) {
+            // This is cosmetic; during processing a worksheet was created
+            // for each table and the last created is set active. When opening
+            // the file in GUI, the last worksheet would open, but it's most
+            // likely desired to view the first worksheet first.
+            $this->excel->setActiveSheetIndex(0);
+        }
+    }
+
+    /**
+     * Set document title.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function titleElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        $this->excel->getProperties()->setTitle($element->textContent);
+    }
+
+    /**
+     * Create a new worksheet and use it as active sheet.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function tableElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        $sheetNum = $this->excel->getSheetCount();
+        $this->excel->createSheet();
+        $this->excel->setActiveSheetIndex($sheetNum);
+        // Row and column need to be reset.
+        $row = 1;
+        $column = 'A';
+        return PHPExcel_Reader_HTML_Abstract::TRAVERSE_CHILDS;
+    }
+
+    /**
+     * Set title of current active sheet.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function captionElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        $this->excel->getActiveSheet()->setTitle($element->textContent);
+    }
+
+    /**
+     * For each header row in thead, create a row with bold formatted columns.
+     * @param \DOMNode $element
+     * @param int $row
+     * @param string $column
+     * @param string $cellContent
+     */
+    protected function theadElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        foreach ($element->childNodes as $child) {
+            if ($this->isElement($child, "tr")) {
+                $this->createHeaderRow($child, $row);
+                $row += 1;
+            }
+        }
+        // Don't traverse childs as they are already traversed in here.
+    }
+
+    protected function tbodyElementHandler(\DOMNode $element, &$row, &$column, &$cellContent)
+    {
+        foreach ($element->childNodes as $child) {
+            if ($this->isElement($child, "tr")) {
+                $this->createDataRow($child, $row);
+                $row += 1;
+            }
+        }
+        // Don't traverse childs as they are already traversed in here.
+    }
+
+    protected function createHeaderRow(\DOMNode $theadRow, $row)
+    {
+        $column = 'A';
+        foreach ($theadRow->childNodes as $child) {
+            if ($this->isElement($child, "th")) {
+                $this->flushCell($column, $row, $child->textContent);
+                $column++;
+            }
+        }
+        // Formatting headers by using range is faster than doing it in the loop.
+        $range = sprintf('A%d:%s%d', $row, $column, $row);
+        $this->excel->getActiveSheet()->getStyle($range)->getFont()->setBold(true);
+    }
+
+    protected function createDataRow(\DOMNode $tbodyRow, $row)
+    {
+        $column = 'A';
+        foreach ($tbodyRow->childNodes as $child) {
+            if ($this->isElement($child, "td")) {
+                $this->flushCell($column, $row, $child->textContent);
+                $column++;
+            }
+        }
+    }
+
+    private function isElement($el, $name) {
+        return $el instanceof \DOMNode && $el->nodeName === $name;
+    }
+
+}


### PR DESCRIPTION
This pull request introduces the new reader PHPExcel_Reader_HTML_SemanticTable. Compared to the existing HTML reader, SemanticTable doesn't try to convert everything table-looking.  Instead only table elements are recognized and each is treated as a worksheet with the children elements caption, thead and tbody parsed as worksheet title, header rows and content rows respectively.

For example, the following HTML portion is recognized by SemanticTable:

    <table>
      <caption>Worksheet name</caption>
      <thead>
        <tr>
          <th>Heading in A1<th>
          <th>Heading in B1</th>
        </tr>
      </thead>
      <tbody>
        <tr>
          <td>Datenspalte A2</td>
          <td>Datenspalte B2</td>
        </tr>
        <tr>
          <td>Datenspalte A3</td>
          <td>Datenspalte B3</td>
        </tr>
      </tbody>
    </table>

To avoid repetitions in PHPExcel_Reader_HTML and PHPExcel_Reader_HTML_SemanticTable, an abstract base class is introduced which is used for common functionality. Care was taken to keep modifications in PHPExcel_Reader_HTML at a minimum, therefore it only uses defaultElementHandler and doesn't use TRAVERSE_CHILDS hint.