### PR TITLE
Allow start and end date of DATEDIF function to be the same.

### DIFF
--- a/Classes/PHPExcel/Calculation/DateTime.php
+++ b/Classes/PHPExcel/Calculation/DateTime.php
@@ -668,7 +668,7 @@ class PHPExcel_Calculation_DateTime
         }
 
         // Validate parameters
-        if ($startDate >= $endDate) {
+        if ($startDate > $endDate) {
             return PHPExcel_Calculation_Functions::NaN();
         }
 


### PR DESCRIPTION
Allow start and end date of DATEDIF function to be the same.

The two values can be the same in Excel, resulting in the value of 0. Currently, PHPExcel returns a "#NUM!" error.
