### PR TITLE
Require Mbstring Extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require": {
         "php": ">=5.2.0",
         "ext-xml": "*",
-        "ext-xmlwriter": "*"
+        "ext-xmlwriter": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*"


### PR DESCRIPTION
Due to a recent change in /Style/NumberFormat.php, mbstring is now a
required extension.  See line #427 in this commit:  https://github.com/PHPOffice/PHPExcel/commit/87ba4290200bd83e2bde5203d2d813a2b59fcb0a