### PR TITLE
Fall back when value is #N/A

### DIFF
--- a/Classes/PHPExcel/Cell.php
+++ b/Classes/PHPExcel/Cell.php
@@ -293,7 +293,7 @@ class PHPExcel_Cell
                 );
             }
 
-            if ($result === '#Not Yet Implemented') {
+            if ($result === '#N/A' || $result === '#Not Yet Implemented') {
 //echo 'Returning fallback value of '.$this->calculatedValue.' for cell '.$this->getCoordinate().PHP_EOL;
                 return $this->calculatedValue; // Fallback if calculation engine does not support the formula.
             }


### PR DESCRIPTION
`getCalculatedValue()` doesn't work properly with my Excel. I have created a test script below, it is returnning '#N/A' but it shouldn't.

File: http://ge.tt/8jaJfiM2/v/0

```php
#!/usr/bin/env php
<?php
(@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
dump((new PHPExcel_Reader_Excel2007())
    ->setReadDataOnly(true)
    ->load($argv[1])
    ->getActiveSheet()
    ->getCell('AL20')
    ->getCalculatedValue()
);
```

This PR should fix it, kindly review.