### PR TITLE
Add gitattributes export-ignore Examples and unitTests.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 /Build export-ignore
 /Documentation export-ignore
+/Examples export-ignore
 /Tests export-ignore
+/unitTests export-ignore
 README.md export-ignore


### PR DESCRIPTION
Prevent them from being included in an composer release.

When composer is used to download dependencies for a release, this can
significantly help limit the amount of wasted transferred files.