### PR TITLE
Suppress error for integer data-series

### DIFF
--- a/Classes/PHPExcel/Chart/DataSeriesValues.php
+++ b/Classes/PHPExcel/Chart/DataSeriesValues.php
@@ -298,7 +298,7 @@ class PHPExcel_Chart_DataSeriesValues
             if ($flatten) {
                 $this->dataValues = PHPExcel_Calculation_Functions::flattenArray($newDataValues);
                 foreach ($this->dataValues as &$dataValue) {
-                    if ((!empty($dataValue)) && ($dataValue[0] == '#')) {
+                    if ((!empty($dataValue)) && (is_string($dataValue)) && ($dataValue[0] == '#')) {
                         $dataValue = 0.0;
                     }
                 }


### PR DESCRIPTION
In my development environment, line 301 throws a warning saying: "Cannot use a scalar value as an array", but the operation completes successfully. I believe that is because the second check on that line assumes that the value is a string, which it isn't in the case of an integer. Adding a is_string check fixes the error.