### PR TITLE
Clarification on the license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "http://phpexcel.codeplex.com",
     "type": "library",
-    "license": "LGPL",
+    "license": "LGPL-3.0",
     "authors": [
         {
             "name": "Maarten Balliauw",


### PR DESCRIPTION
I currently oversee the licenses used in our projects.

I would like to ask you to clarify the license in composer.json in order to comply with the license identifiers as listed by SPDX
http://spdx.org/licenses/

Reasoning:
"LGPL" could imply any version of the license, some of which have certain (usually, but not always, minor) consequences for derivative works.
For details e.g. see http://www.gnu.org/licenses/gpl-faq.html#AllCompatibility
Given the files in this repository, it was clear to me that you either intended to apply "LGPL-3.0" or "LGPL-3.0+" (LGPL 3.0 or later).