### PR TITLE
Setting font on chart title

### DIFF
--- a/Classes/PHPExcel/Chart/Title.php
+++ b/Classes/PHPExcel/Chart/Title.php
@@ -43,12 +43,23 @@ class PHPExcel_Chart_Title
     private $layout = null;
 
     /**
+     * Title Font
+     *
+     * @var PHPExcel_Style_Font
+     */
+    private $font = null;
+
+    /**
      * Create a new PHPExcel_Chart_Title
+     *
+     * @param string $caption
+     * @param PHPExcel_Chart_Layout $layout
      */
     public function __construct($caption = null, PHPExcel_Chart_Layout $layout = null)
     {
         $this->caption = $caption;
         $this->layout = $layout;
+        $this->font = new PHPExcel_Style_Font();
     }
 
     /**
@@ -83,4 +94,26 @@ class PHPExcel_Chart_Title
     {
         return $this->layout;
     }
+
+    /**
+     * Get font
+     *
+     * @return PHPExcel_Style_Font
+     */
+    public function getFont() {
+        return $this->font;
+    }
+
+    /**
+     * Set font
+     *
+     * @param PHPExcel_Style_Font $font
+     * @return PHPExcel_Chart_Title
+     */
+    public function setFont(PHPExcel_Style_Font $font = null) {
+        $this->font = $font;
+
+        return $this;
+    }
+
 }

--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -132,7 +132,15 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
         if ((is_array($caption)) && (count($caption) > 0)) {
             $caption = $caption[0];
         }
-        $this->getParentWriter()->getWriterPart('stringtable')->writeRichTextForCharts($objWriter, $caption, 'a');
+
+        $pRichText = new PHPExcel_RichText();
+        $pRichText->createTextRun($caption);
+        $elements = $pRichText->getRichTextElements();
+        foreach ($elements as $element) {
+            $element->setFont($title->getFont());
+        }
+
+        $this->getParentWriter()->getWriterPart('stringtable')->writeRichTextForCharts($objWriter, $pRichText, 'a');
 
         $objWriter->endElement();
         $objWriter->endElement();

--- a/Classes/PHPExcel/Writer/Excel2007/StringTable.php
+++ b/Classes/PHPExcel/Writer/Excel2007/StringTable.php
@@ -276,6 +276,14 @@ class PHPExcel_Writer_Excel2007_StringTable extends PHPExcel_Writer_Excel2007_Wr
 //                        $objWriter->endElement();
 //                    }
 //
+
+            // Color
+            $objWriter->startElement($prefix.'solidFill');
+                $objWriter->startElement($prefix.'srgbClr');
+                    $objWriter->writeAttribute('val',$element->getFont()->getColor()->getRGB());
+                $objWriter->endElement();
+            $objWriter->endElement();
+
             $objWriter->endElement();
 
             // t


### PR DESCRIPTION
Added the ability to set the font on a chart title so the colour can be changed or text made bold/italic etc

e.g

$title = new PHPExcel_Chart_Title("My Title");
$title->getFont()->setItalic(true)->setStrikethrough(true)->getColor()->setRgb('ff0000');
$chart = new PHPExcel_Chart('chart',$title....
