### PR TITLE
Update copyright year and URL

### DIFF
--- a/Build/build.xml
+++ b/Build/build.xml
@@ -164,7 +164,7 @@
                 to Excel 2007 files and read from Excel 2007 files.
             </description>
             <notes>This package ONLY contains the class files, not the documentation and example code. Please refer to
-                http://www.codeplex.com/PHPExcel for those files.
+                https://github.com/PHPOffice/PHPExcel for those files.
             </notes>
             <lead user="maartenba" name="Maarten Balliauw" email="maarten@phpexcel.net"/>
             <license uri="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL</license>

--- a/Classes/PHPExcel.php
+++ b/Classes/PHPExcel.php
@@ -27,7 +27,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Autoloader.php
+++ b/Classes/PHPExcel/Autoloader.php
@@ -31,7 +31,7 @@ PHPExcel_Shared_String::buildCharacterSets();
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/APC.php
+++ b/Classes/PHPExcel/CachedObjectStorage/APC.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
+++ b/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
+++ b/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/ICache.php
+++ b/Classes/PHPExcel/CachedObjectStorage/ICache.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/Igbinary.php
+++ b/Classes/PHPExcel/CachedObjectStorage/Igbinary.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/Memcache.php
+++ b/Classes/PHPExcel/CachedObjectStorage/Memcache.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/Memory.php
+++ b/Classes/PHPExcel/CachedObjectStorage/Memory.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/MemoryGZip.php
+++ b/Classes/PHPExcel/CachedObjectStorage/MemoryGZip.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/MemorySerialized.php
+++ b/Classes/PHPExcel/CachedObjectStorage/MemorySerialized.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/PHPTemp.php
+++ b/Classes/PHPExcel/CachedObjectStorage/PHPTemp.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/SQLite.php
+++ b/Classes/PHPExcel/CachedObjectStorage/SQLite.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/SQLite3.php
+++ b/Classes/PHPExcel/CachedObjectStorage/SQLite3.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorage/Wincache.php
+++ b/Classes/PHPExcel/CachedObjectStorage/Wincache.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CachedObjectStorageFactory.php
+++ b/Classes/PHPExcel/CachedObjectStorageFactory.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_CachedObjectStorage
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CalcEngine/CyclicReferenceStack.php
+++ b/Classes/PHPExcel/CalcEngine/CyclicReferenceStack.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/CalcEngine/Logger.php
+++ b/Classes/PHPExcel/CalcEngine/Logger.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation.php
+++ b/Classes/PHPExcel/Calculation.php
@@ -45,7 +45,7 @@ if (!defined('CALCULATION_REGEXP_CELLREF')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Database.php
+++ b/Classes/PHPExcel/Calculation/Database.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/DateTime.php
+++ b/Classes/PHPExcel/Calculation/DateTime.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Engineering.php
+++ b/Classes/PHPExcel/Calculation/Engineering.php
@@ -33,7 +33,7 @@ define('EULER', 2.71828182845904523536);
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Exception.php
+++ b/Classes/PHPExcel/Calculation/Exception.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/ExceptionHandler.php
+++ b/Classes/PHPExcel/Calculation/ExceptionHandler.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Financial.php
+++ b/Classes/PHPExcel/Calculation/Financial.php
@@ -36,7 +36,7 @@ define('FINANCIAL_PRECISION', 1.0e-08);
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/FormulaParser.php
+++ b/Classes/PHPExcel/Calculation/FormulaParser.php
@@ -44,7 +44,7 @@ PARTLY BASED ON:
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/FormulaToken.php
+++ b/Classes/PHPExcel/Calculation/FormulaToken.php
@@ -44,7 +44,7 @@ PARTLY BASED ON:
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Function.php
+++ b/Classes/PHPExcel/Calculation/Function.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -44,7 +44,7 @@ define('PRECISION', 8.88E-016);
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Logical.php
+++ b/Classes/PHPExcel/Calculation/Logical.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/LookupRef.php
+++ b/Classes/PHPExcel/Calculation/LookupRef.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/MathTrig.php
+++ b/Classes/PHPExcel/Calculation/MathTrig.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Statistical.php
+++ b/Classes/PHPExcel/Calculation/Statistical.php
@@ -46,7 +46,7 @@ define('SQRT2PI', 2.5066282746310005024157652848110452530069867406099);
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/TextData.php
+++ b/Classes/PHPExcel/Calculation/TextData.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category    PHPExcel
  * @package        PHPExcel_Calculation
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Calculation/Token/Stack.php
+++ b/Classes/PHPExcel/Calculation/Token/Stack.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Calculation
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell.php
+++ b/Classes/PHPExcel/Cell.php
@@ -21,7 +21,7 @@
  *
  *    @category    PHPExcel
  *    @package    PHPExcel_Cell
- *    @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *    @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *    @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *    @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/AdvancedValueBinder.php
+++ b/Classes/PHPExcel/Cell/AdvancedValueBinder.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/DataType.php
+++ b/Classes/PHPExcel/Cell/DataType.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/DataValidation.php
+++ b/Classes/PHPExcel/Cell/DataValidation.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/Hyperlink.php
+++ b/Classes/PHPExcel/Cell/Hyperlink.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Cell/IValueBinder.php
+++ b/Classes/PHPExcel/Cell/IValueBinder.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -32,7 +32,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Cell
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 interface PHPExcel_Cell_IValueBinder
 {

--- a/Classes/PHPExcel/Chart.php
+++ b/Classes/PHPExcel/Chart.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/DataSeries.php
+++ b/Classes/PHPExcel/Chart/DataSeries.php
@@ -20,7 +20,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Chart_DataSeries
 {

--- a/Classes/PHPExcel/Chart/DataSeriesValues.php
+++ b/Classes/PHPExcel/Chart/DataSeriesValues.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/Exception.php
+++ b/Classes/PHPExcel/Chart/Exception.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Chart
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/Layout.php
+++ b/Classes/PHPExcel/Chart/Layout.php
@@ -20,7 +20,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Chart_Layout
 {

--- a/Classes/PHPExcel/Chart/Legend.php
+++ b/Classes/PHPExcel/Chart/Legend.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/PlotArea.php
+++ b/Classes/PHPExcel/Chart/PlotArea.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/Renderer/jpgraph.php
+++ b/Classes/PHPExcel/Chart/Renderer/jpgraph.php
@@ -23,7 +23,7 @@ require_once(PHPExcel_Settings::getChartRendererPath().'/jpgraph.php');
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart_Renderer
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Chart/Title.php
+++ b/Classes/PHPExcel/Chart/Title.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Chart
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Comment.php
+++ b/Classes/PHPExcel/Comment.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/DocumentProperties.php
+++ b/Classes/PHPExcel/DocumentProperties.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package    PHPExcel
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/DocumentSecurity.php
+++ b/Classes/PHPExcel/DocumentSecurity.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Exception.php
+++ b/Classes/PHPExcel/Exception.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Exception extends Exception
 {

--- a/Classes/PHPExcel/HashTable.php
+++ b/Classes/PHPExcel/HashTable.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/IComparable.php
+++ b/Classes/PHPExcel/IComparable.php
@@ -19,7 +19,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/IOFactory.php
+++ b/Classes/PHPExcel/IOFactory.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/NamedRange.php
+++ b/Classes/PHPExcel/NamedRange.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Abstract.php
+++ b/Classes/PHPExcel/Reader/Abstract.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/CSV.php
+++ b/Classes/PHPExcel/Reader/CSV.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/DefaultReadFilter.php
+++ b/Classes/PHPExcel/Reader/DefaultReadFilter.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Reader/Excel2007/Chart.php
@@ -20,7 +20,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Reader_Excel2007
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */
@@ -30,7 +30,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Reader_Excel2007
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Reader_Excel2007_Chart
 {

--- a/Classes/PHPExcel/Reader/Excel2007/Theme.php
+++ b/Classes/PHPExcel/Reader/Excel2007/Theme.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Reader_Excel2007_Theme
 {

--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel5/Escher.php
+++ b/Classes/PHPExcel/Reader/Excel5/Escher.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel5/MD5.php
+++ b/Classes/PHPExcel/Reader/Excel5/MD5.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt        LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Excel5/RC4.php
+++ b/Classes/PHPExcel/Reader/Excel5/RC4.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Exception.php
+++ b/Classes/PHPExcel/Reader/Exception.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/Gnumeric.php
+++ b/Classes/PHPExcel/Reader/Gnumeric.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -29,7 +29,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/IReadFilter.php
+++ b/Classes/PHPExcel/Reader/IReadFilter.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/IReader.php
+++ b/Classes/PHPExcel/Reader/IReader.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/OOCalc.php
+++ b/Classes/PHPExcel/Reader/OOCalc.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Reader/SYLK.php
+++ b/Classes/PHPExcel/Reader/SYLK.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Reader
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/RichText.php
+++ b/Classes/PHPExcel/RichText.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_RichText
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/RichText/ITextElement.php
+++ b/Classes/PHPExcel/RichText/ITextElement.php
@@ -19,7 +19,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_RichText
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/RichText/Run.php
+++ b/Classes/PHPExcel/RichText/Run.php
@@ -19,7 +19,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_RichText
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/RichText/TextElement.php
+++ b/Classes/PHPExcel/RichText/TextElement.php
@@ -19,7 +19,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_RichText
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Settings.php
+++ b/Classes/PHPExcel/Settings.php
@@ -30,7 +30,7 @@ if (!defined('PHPEXCEL_ROOT')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Settings
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/CodePage.php
+++ b/Classes/PHPExcel/Shared/CodePage.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Date.php
+++ b/Classes/PHPExcel/Shared/Date.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Drawing.php
+++ b/Classes/PHPExcel/Shared/Drawing.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Shared_Drawing
 {

--- a/Classes/PHPExcel/Shared/Escher.php
+++ b/Classes/PHPExcel/Shared/Escher.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DgContainer.php
+++ b/Classes/PHPExcel/Shared/Escher/DgContainer.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DgContainer/SpgrContainer.php
+++ b/Classes/PHPExcel/Shared/Escher/DgContainer/SpgrContainer.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DgContainer/SpgrContainer/SpContainer.php
+++ b/Classes/PHPExcel/Shared/Escher/DgContainer/SpgrContainer/SpContainer.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DggContainer.php
+++ b/Classes/PHPExcel/Shared/Escher/DggContainer.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer.php
+++ b/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer/BSE.php
+++ b/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer/BSE.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer/BSE/Blip.php
+++ b/Classes/PHPExcel/Shared/Escher/DggContainer/BstoreContainer/BSE/Blip.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Escher
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Excel5.php
+++ b/Classes/PHPExcel/Shared/Excel5.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/File.php
+++ b/Classes/PHPExcel/Shared/File.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/Font.php
+++ b/Classes/PHPExcel/Shared/Font.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Shared_Font
 {

--- a/Classes/PHPExcel/Shared/OLERead.php
+++ b/Classes/PHPExcel/Shared/OLERead.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/PasswordHasher.php
+++ b/Classes/PHPExcel/Shared/PasswordHasher.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Shared_PasswordHasher
 {

--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/TimeZone.php
+++ b/Classes/PHPExcel/Shared/TimeZone.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -32,7 +32,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Shared_TimeZone
 {

--- a/Classes/PHPExcel/Shared/XMLWriter.php
+++ b/Classes/PHPExcel/Shared/XMLWriter.php
@@ -29,7 +29,7 @@ if (!defined('DEBUGMODE_ENABLED')) {
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/ZipArchive.php
+++ b/Classes/PHPExcel/Shared/ZipArchive.php
@@ -26,7 +26,7 @@ require_once PHPEXCEL_ROOT . 'PHPExcel/Shared/PCLZip/pclzip.lib.php';
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_ZipArchive
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/ZipStreamWrapper.php
+++ b/Classes/PHPExcel/Shared/ZipStreamWrapper.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/bestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/bestFitClass.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/exponentialBestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/exponentialBestFitClass.php
@@ -23,7 +23,7 @@ require_once(PHPEXCEL_ROOT . 'PHPExcel/Shared/trend/bestFitClass.php');
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/linearBestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/linearBestFitClass.php
@@ -23,7 +23,7 @@ require_once(PHPEXCEL_ROOT . 'PHPExcel/Shared/trend/bestFitClass.php');
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/logarithmicBestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/logarithmicBestFitClass.php
@@ -23,7 +23,7 @@ require_once(PHPEXCEL_ROOT . 'PHPExcel/Shared/trend/bestFitClass.php');
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/polynomialBestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/polynomialBestFitClass.php
@@ -24,7 +24,7 @@ require_once PHPEXCEL_ROOT . 'PHPExcel/Shared/JAMA/Matrix.php';
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/powerBestFitClass.php
+++ b/Classes/PHPExcel/Shared/trend/powerBestFitClass.php
@@ -23,7 +23,7 @@ require_once PHPEXCEL_ROOT . 'PHPExcel/Shared/trend/bestFitClass.php';
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Shared/trend/trendClass.php
+++ b/Classes/PHPExcel/Shared/trend/trendClass.php
@@ -27,7 +27,7 @@ require_once PHPEXCEL_ROOT . 'PHPExcel/Shared/trend/polynomialBestFitClass.php';
  *
  * @category   PHPExcel
  * @package    PHPExcel_Shared_Trend
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style.php
+++ b/Classes/PHPExcel/Style.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Alignment.php
+++ b/Classes/PHPExcel/Style/Alignment.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Border.php
+++ b/Classes/PHPExcel/Style/Border.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Borders.php
+++ b/Classes/PHPExcel/Style/Borders.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Color.php
+++ b/Classes/PHPExcel/Style/Color.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Conditional.php
+++ b/Classes/PHPExcel/Style/Conditional.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Style_Conditional implements PHPExcel_IComparable
 {

--- a/Classes/PHPExcel/Style/Fill.php
+++ b/Classes/PHPExcel/Style/Fill.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Font.php
+++ b/Classes/PHPExcel/Style/Font.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Protection.php
+++ b/Classes/PHPExcel/Style/Protection.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Style/Supervisor.php
+++ b/Classes/PHPExcel/Style/Supervisor.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Style
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/AutoFilter.php
+++ b/Classes/PHPExcel/Worksheet/AutoFilter.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/AutoFilter/Column.php
+++ b/Classes/PHPExcel/Worksheet/AutoFilter/Column.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Worksheet
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/AutoFilter/Column/Rule.php
+++ b/Classes/PHPExcel/Worksheet/AutoFilter/Column/Rule.php
@@ -21,7 +21,7 @@
  *
  * @category    PHPExcel
  * @package        PHPExcel_Worksheet
- * @copyright    Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright    Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license        http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version        ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/BaseDrawing.php
+++ b/Classes/PHPExcel/Worksheet/BaseDrawing.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/CellIterator.php
+++ b/Classes/PHPExcel/Worksheet/CellIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/Column.php
+++ b/Classes/PHPExcel/Worksheet/Column.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/ColumnCellIterator.php
+++ b/Classes/PHPExcel/Worksheet/ColumnCellIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/ColumnDimension.php
+++ b/Classes/PHPExcel/Worksheet/ColumnDimension.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/ColumnIterator.php
+++ b/Classes/PHPExcel/Worksheet/ColumnIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/Dimension.php
+++ b/Classes/PHPExcel/Worksheet/Dimension.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/Drawing.php
+++ b/Classes/PHPExcel/Worksheet/Drawing.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet_Drawing
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/Drawing/Shadow.php
+++ b/Classes/PHPExcel/Worksheet/Drawing/Shadow.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet_Drawing
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/HeaderFooter.php
+++ b/Classes/PHPExcel/Worksheet/HeaderFooter.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  *

--- a/Classes/PHPExcel/Worksheet/HeaderFooterDrawing.php
+++ b/Classes/PHPExcel/Worksheet/HeaderFooterDrawing.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/MemoryDrawing.php
+++ b/Classes/PHPExcel/Worksheet/MemoryDrawing.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/PageMargins.php
+++ b/Classes/PHPExcel/Worksheet/PageMargins.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Worksheet_PageMargins
 {

--- a/Classes/PHPExcel/Worksheet/PageSetup.php
+++ b/Classes/PHPExcel/Worksheet/PageSetup.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -102,7 +102,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Worksheet_PageSetup
 {

--- a/Classes/PHPExcel/Worksheet/Protection.php
+++ b/Classes/PHPExcel/Worksheet/Protection.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Worksheet_Protection
 {

--- a/Classes/PHPExcel/Worksheet/Row.php
+++ b/Classes/PHPExcel/Worksheet/Row.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/RowCellIterator.php
+++ b/Classes/PHPExcel/Worksheet/RowCellIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/RowDimension.php
+++ b/Classes/PHPExcel/Worksheet/RowDimension.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/RowIterator.php
+++ b/Classes/PHPExcel/Worksheet/RowIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Worksheet/SheetView.php
+++ b/Classes/PHPExcel/Worksheet/SheetView.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Worksheet
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/WorksheetIterator.php
+++ b/Classes/PHPExcel/WorksheetIterator.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Abstract.php
+++ b/Classes/PHPExcel/Writer/Abstract.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/CSV.php
+++ b/Classes/PHPExcel/Writer/CSV.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_CSV
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007.php
+++ b/Classes/PHPExcel/Writer/Excel2007.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Comments.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Comments.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/ContentTypes.php
+++ b/Classes/PHPExcel/Writer/Excel2007/ContentTypes.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/DocProps.php
+++ b/Classes/PHPExcel/Writer/Excel2007/DocProps.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Drawing.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Drawing.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Rels.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Rels.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/RelsRibbon.php
+++ b/Classes/PHPExcel/Writer/Excel2007/RelsRibbon.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/RelsVBA.php
+++ b/Classes/PHPExcel/Writer/Excel2007/RelsVBA.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/StringTable.php
+++ b/Classes/PHPExcel/Writer/Excel2007/StringTable.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Style.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Style.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Theme.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Theme.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Writer_Excel2007_Theme extends PHPExcel_Writer_Excel2007_WriterPart
 {

--- a/Classes/PHPExcel/Writer/Excel2007/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Workbook.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_WriterPart
 {

--- a/Classes/PHPExcel/Writer/Excel2007/WriterPart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/WriterPart.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel2007
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5.php
+++ b/Classes/PHPExcel/Writer/Excel5.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/BIFFwriter.php
+++ b/Classes/PHPExcel/Writer/Excel5/BIFFwriter.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/Escher.php
+++ b/Classes/PHPExcel/Writer/Excel5/Escher.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  */
 class PHPExcel_Writer_Excel5_Escher
 {

--- a/Classes/PHPExcel/Writer/Excel5/Font.php
+++ b/Classes/PHPExcel/Writer/Excel5/Font.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/Parser.php
+++ b/Classes/PHPExcel/Writer/Excel5/Parser.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel5/Workbook.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel5/Worksheet.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Excel5/Xf.php
+++ b/Classes/PHPExcel/Writer/Excel5/Xf.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_Excel5
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/Exception.php
+++ b/Classes/PHPExcel/Writer/Exception.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_HTML
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/IWriter.php
+++ b/Classes/PHPExcel/Writer/IWriter.php
@@ -21,7 +21,7 @@
  *
  *  @category   PHPExcel
  *  @package    PHPExcel_Writer
- *  @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument.php
+++ b/Classes/PHPExcel/Writer/OpenDocument.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/Cell/Comment.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Cell/Comment.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @author     Alexander Pervakov <frost-nzcr4@jagmort.com>
  */
 class PHPExcel_Writer_OpenDocument_Cell_Comment

--- a/Classes/PHPExcel/Writer/OpenDocument/Content.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Content.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */
@@ -31,7 +31,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @author     Alexander Pervakov <frost-nzcr4@jagmort.com>
  */
 class PHPExcel_Writer_OpenDocument_Content extends PHPExcel_Writer_OpenDocument_WriterPart

--- a/Classes/PHPExcel/Writer/OpenDocument/Meta.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Meta.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/MetaInf.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/MetaInf.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/Mimetype.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Mimetype.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/Settings.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Settings.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/Styles.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Styles.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/Thumbnails.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/Thumbnails.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/OpenDocument/WriterPart.php
+++ b/Classes/PHPExcel/Writer/OpenDocument/WriterPart.php
@@ -21,7 +21,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel_Writer_OpenDocument
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/PDF.php
+++ b/Classes/PHPExcel/Writer/PDF.php
@@ -21,7 +21,7 @@
  *
  *  @category    PHPExcel
  *  @package     PHPExcel_Writer_PDF
- *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license     http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/PDF/Core.php
+++ b/Classes/PHPExcel/Writer/PDF/Core.php
@@ -21,7 +21,7 @@
  *
  *  @category    PHPExcel
  *  @package     PHPExcel_Writer_PDF
- *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license     http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/PDF/DomPDF.php
+++ b/Classes/PHPExcel/Writer/PDF/DomPDF.php
@@ -29,7 +29,7 @@ if (file_exists($pdfRendererClassFile)) {
  *
  *  @category    PHPExcel
  *  @package     PHPExcel_Writer_PDF
- *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license     http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/PDF/mPDF.php
+++ b/Classes/PHPExcel/Writer/PDF/mPDF.php
@@ -29,7 +29,7 @@ if (file_exists($pdfRendererClassFile)) {
  *
  *  @category    PHPExcel
  *  @package     PHPExcel_Writer_PDF
- *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license     http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/Writer/PDF/tcPDF.php
+++ b/Classes/PHPExcel/Writer/PDF/tcPDF.php
@@ -30,7 +30,7 @@ if (file_exists($pdfRendererClassFile)) {
  *
  *  @category    PHPExcel
  *  @package     PHPExcel_Writer_PDF
- *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ *  @copyright   Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  *  @license     http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
  *  @version     ##VERSION##, ##DATE##
  */

--- a/Classes/PHPExcel/locale/bg/config
+++ b/Classes/PHPExcel/locale/bg/config
@@ -20,7 +20,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt  LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/cs/config
+++ b/Classes/PHPExcel/locale/cs/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/cs/functions
+++ b/Classes/PHPExcel/locale/cs/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/da/config
+++ b/Classes/PHPExcel/locale/da/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/da/functions
+++ b/Classes/PHPExcel/locale/da/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/de/config
+++ b/Classes/PHPExcel/locale/de/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/de/functions
+++ b/Classes/PHPExcel/locale/de/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/en/uk/config
+++ b/Classes/PHPExcel/locale/en/uk/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/es/config
+++ b/Classes/PHPExcel/locale/es/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/es/functions
+++ b/Classes/PHPExcel/locale/es/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/fi/config
+++ b/Classes/PHPExcel/locale/fi/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/fi/functions
+++ b/Classes/PHPExcel/locale/fi/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/fr/config
+++ b/Classes/PHPExcel/locale/fr/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/fr/functions
+++ b/Classes/PHPExcel/locale/fr/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/hu/config
+++ b/Classes/PHPExcel/locale/hu/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/hu/functions
+++ b/Classes/PHPExcel/locale/hu/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/it/config
+++ b/Classes/PHPExcel/locale/it/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/it/functions
+++ b/Classes/PHPExcel/locale/it/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/nl/config
+++ b/Classes/PHPExcel/locale/nl/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/nl/functions
+++ b/Classes/PHPExcel/locale/nl/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/no/config
+++ b/Classes/PHPExcel/locale/no/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/no/functions
+++ b/Classes/PHPExcel/locale/no/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/pl/config
+++ b/Classes/PHPExcel/locale/pl/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/pl/functions
+++ b/Classes/PHPExcel/locale/pl/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/pt/br/config
+++ b/Classes/PHPExcel/locale/pt/br/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/pt/config
+++ b/Classes/PHPExcel/locale/pt/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/ru/config
+++ b/Classes/PHPExcel/locale/ru/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/ru/functions
+++ b/Classes/PHPExcel/locale/ru/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/sv/config
+++ b/Classes/PHPExcel/locale/sv/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/tr/config
+++ b/Classes/PHPExcel/locale/tr/config
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Settings
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Classes/PHPExcel/locale/tr/functions
+++ b/Classes/PHPExcel/locale/tr/functions
@@ -19,7 +19,7 @@
 ##
 ## @category   PHPExcel
 ## @package    PHPExcel_Calculation
-## @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+## @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 ## @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 ## @version    ##VERSION##, ##DATE##
 ##

--- a/Documentation/markdown/CalculationEngine/FunctionReference/01-Introduction.md
+++ b/Documentation/markdown/CalculationEngine/FunctionReference/01-Introduction.md
@@ -2,10 +2,10 @@
 
 ## Frequently asked questions
 
-The up-to-date F.A.Q. page for PHPExcel can be found on [http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements][1].
+The up-to-date F.A.Q. page for PHPExcel can be found on [https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements][1].
 
 ### Formulas don’t seem to be calculated in Excel2003 using compatibility pack?
 
 This is normal behaviour of the compatibility pack, Excel2007 displays this correctly. Use PHPExcel_Writer_Excel5 if you really need calculated values, or force recalculation in Excel2003.
 
-  [1]: http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements
+  [1]: https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements

--- a/Documentation/markdown/Overview/01-Getting-Started.md
+++ b/Documentation/markdown/Overview/01-Getting-Started.md
@@ -63,7 +63,7 @@ There are some links and tools which are very useful when developing using PHPEx
 
 ### Frequently asked questions
 
-The up-to-date F.A.Q. page for PHPExcel can be found on [http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements][7].
+The up-to-date F.A.Q. page for PHPExcel can be found on [https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements][7].
 
 ##### There seems to be a problem with character encoding...
 
@@ -155,12 +155,12 @@ Thanks to peterrlynch for the following advice on resolving issues between the [
   [http://journal.mycom.co.jp/articles/2009/03/06/phpexcel/index.html][21]
 
 
-  [2]: http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=Documents&referringTitle=Home
+  [2]: https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=Documents&referringTitle=Home
   [3]: http://www.ecma-international.org/news/TC45_current_work/TC45_available_docs.htm
   [4]: http://openxmldeveloper.org/articles/1970.aspx
   [5]: http://www.microsoft.com/downloads/details.aspx?familyid=941b3470-3ae9-4aee-8f43-c6bb74cd1466&displaylang=en
   [6]: http://www.codeplex.com/PackageExplorer/
-  [7]: http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements
+  [7]: https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=FAQ&referringTitle=Requirements
   [8]: http://snaps.php.net/win32/php5.2-win32-latest.zip
   [9]: http://phpexcel.codeplex.com/Thread/View.aspx?ThreadId=234150
   [10]: http://phpexcel.codeplex.com/Thread/View.aspx?ThreadId=242712

--- a/Documentation/markdown/Overview/10-Reading-and-Writing.md
+++ b/Documentation/markdown/Overview/10-Reading-and-Writing.md
@@ -711,4 +711,4 @@ $objWriter->save('write.xls');
 Notice that it is ok to load an xlsx file and generate an xls file.
 
   [21]: http://pear.php.net/package/Spreadsheet_Excel_Writer
-  [22]: http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home
+  [22]: https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home

--- a/Documentation/markdown/Overview/11-Appendices.md
+++ b/Documentation/markdown/Overview/11-Appendices.md
@@ -2,7 +2,7 @@
 
 ## Credits
 
-Please refer to the internet page [http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home][22] for up-to-date credits.
+Please refer to the internet page [https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home][22] for up-to-date credits.
 
 ## Valid array keys for style applyFromArray()
 
@@ -97,4 +97,4 @@ __PHPExcel_Style_Protection__
     hidden    | setHidden()
 
 
-  [22]: http://www.codeplex.com/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home
+  [22]: https://github.com/PHPOffice/PHPExcel/Wiki/View.aspx?title=Credits&referringTitle=Home

--- a/Examples/01pharSimple.php
+++ b/Examples/01pharSimple.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simple-download-ods.php
+++ b/Examples/01simple-download-ods.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simple-download-pdf.php
+++ b/Examples/01simple-download-pdf.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simple-download-xls.php
+++ b/Examples/01simple-download-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simple-download-xlsx.php
+++ b/Examples/01simple-download-xlsx.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simple.php
+++ b/Examples/01simple.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/01simplePCLZip.php
+++ b/Examples/01simplePCLZip.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/02types-xls.php
+++ b/Examples/02types-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/02types.php
+++ b/Examples/02types.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/03formulas.php
+++ b/Examples/03formulas.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/04printing.php
+++ b/Examples/04printing.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/05featuredemo.inc.php
+++ b/Examples/05featuredemo.inc.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/05featuredemo.php
+++ b/Examples/05featuredemo.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/06largescale-with-cellcaching-sqlite.php
+++ b/Examples/06largescale-with-cellcaching-sqlite.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/06largescale-with-cellcaching-sqlite3.php
+++ b/Examples/06largescale-with-cellcaching-sqlite3.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/06largescale-with-cellcaching.php
+++ b/Examples/06largescale-with-cellcaching.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/06largescale-xls.php
+++ b/Examples/06largescale-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/06largescale.php
+++ b/Examples/06largescale.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/07reader.php
+++ b/Examples/07reader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/07readerPCLZip.php
+++ b/Examples/07readerPCLZip.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/08conditionalformatting.php
+++ b/Examples/08conditionalformatting.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/08conditionalformatting2.php
+++ b/Examples/08conditionalformatting2.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/09pagebreaks.php
+++ b/Examples/09pagebreaks.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/10autofilter-selection-1.php
+++ b/Examples/10autofilter-selection-1.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/10autofilter-selection-2.php
+++ b/Examples/10autofilter-selection-2.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/10autofilter-selection-display.php
+++ b/Examples/10autofilter-selection-display.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/10autofilter.php
+++ b/Examples/10autofilter.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/11documentsecurity-xls.php
+++ b/Examples/11documentsecurity-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/11documentsecurity.php
+++ b/Examples/11documentsecurity.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/12cellProtection.php
+++ b/Examples/12cellProtection.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/13calculation.php
+++ b/Examples/13calculation.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/13calculationCyclicFormulae.php
+++ b/Examples/13calculationCyclicFormulae.php
@@ -2,7 +2,7 @@
 /**
  * PHPExcel
  *
- * Copyright (C) 2006 - 2014 PHPExcel
+ * Copyright (C) 2006 - 2015 PHPExcel
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2014 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/14excel5.php
+++ b/Examples/14excel5.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/15datavalidation-xls.php
+++ b/Examples/15datavalidation-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/15datavalidation.php
+++ b/Examples/15datavalidation.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/16csv.php
+++ b/Examples/16csv.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/17html.php
+++ b/Examples/17html.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/18extendedcalculation.php
+++ b/Examples/18extendedcalculation.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/19namedrange.php
+++ b/Examples/19namedrange.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/20readexcel5.php
+++ b/Examples/20readexcel5.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/21pdf.php
+++ b/Examples/21pdf.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/22heavilyformatted.php
+++ b/Examples/22heavilyformatted.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/23sharedstyles.php
+++ b/Examples/23sharedstyles.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/24readfilter.php
+++ b/Examples/24readfilter.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/25inmemoryimage.php
+++ b/Examples/25inmemoryimage.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/26utf8.php
+++ b/Examples/26utf8.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/27imagesexcel5.php
+++ b/Examples/27imagesexcel5.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/28iterator.php
+++ b/Examples/28iterator.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/29advancedvaluebinder.php
+++ b/Examples/29advancedvaluebinder.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/30template.php
+++ b/Examples/30template.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/31docproperties_write-xls.php
+++ b/Examples/31docproperties_write-xls.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/31docproperties_write.php
+++ b/Examples/31docproperties_write.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/32chartreadwrite.php
+++ b/Examples/32chartreadwrite.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-area.php
+++ b/Examples/33chartcreate-area.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-bar-stacked.php
+++ b/Examples/33chartcreate-bar-stacked.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-bar.php
+++ b/Examples/33chartcreate-bar.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-column-2.php
+++ b/Examples/33chartcreate-column-2.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-column.php
+++ b/Examples/33chartcreate-column.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-composite.php
+++ b/Examples/33chartcreate-composite.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-line.php
+++ b/Examples/33chartcreate-line.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-multiple-charts.php
+++ b/Examples/33chartcreate-multiple-charts.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-pie.php
+++ b/Examples/33chartcreate-pie.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-radar.php
+++ b/Examples/33chartcreate-radar.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-scatter.php
+++ b/Examples/33chartcreate-scatter.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/33chartcreate-stock.php
+++ b/Examples/33chartcreate-stock.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/34chartupdate.php
+++ b/Examples/34chartupdate.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/35chartrender.php
+++ b/Examples/35chartrender.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/36chartreadwriteHTML.php
+++ b/Examples/36chartreadwriteHTML.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/36chartreadwritePDF.php
+++ b/Examples/36chartreadwritePDF.php
@@ -31,7 +31,7 @@ date_default_timezone_set('Europe/London');
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/37page_layout_view.php
+++ b/Examples/37page_layout_view.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/38cloneWorksheet.php
+++ b/Examples/38cloneWorksheet.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/39dropdown.php
+++ b/Examples/39dropdown.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/41password.php
+++ b/Examples/41password.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/42richText.php
+++ b/Examples/42richText.php
@@ -2,7 +2,7 @@
 /**
  * PHPExcel
  *
- * Copyright (C) 2006 - 2014 PHPExcel
+ * Copyright (C) 2006 - 2015 PHPExcel
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2014 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/43mergeWorkbooks.php
+++ b/Examples/43mergeWorkbooks.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/Excel2003XMLReader.php
+++ b/Examples/Excel2003XMLReader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/GnumericReader.php
+++ b/Examples/GnumericReader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/OOCalcReader.php
+++ b/Examples/OOCalcReader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/OOCalcReaderPCLZip.php
+++ b/Examples/OOCalcReaderPCLZip.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/SylkReader.php
+++ b/Examples/SylkReader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/XMLReader.php
+++ b/Examples/XMLReader.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/Examples/runall.php
+++ b/Examples/runall.php
@@ -20,7 +20,7 @@
  *
  * @category   PHPExcel
  * @package    PHPExcel
- * @copyright  Copyright (c) 2006 - 2015 PHPExcel (http://www.codeplex.com/PHPExcel)
+ * @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
  * @version    ##VERSION##, ##DATE##
  */

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 **************************************************************************************
 * PHPExcel
 *
-* Copyright (c) 2006 - 2014 PHPExcel
+* Copyright (c) 2006 - 2015 PHPExcel
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
@@ -17,7 +17,7 @@
 * License along with this library; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 *
-* @copyright  Copyright (c) 2006 - 2014 PHPExcel (http://www.codeplex.com/PHPExcel)
+* @copyright  Copyright (c) 2006 - 2015 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt    LGPL
 * @version    ##VERSION##, ##DATE##
 **************************************************************************************

--- a/install.txt
+++ b/install.txt
@@ -17,7 +17,7 @@
 * License along with this library; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 *
-* @copyright  Copyright (c) 2006 - 2013 PHPExcel (http://www.codeplex.com/PHPExcel)
+* @copyright  Copyright (c) 2006 - 2013 PHPExcel (https://github.com/PHPOffice/PHPExcel)
 * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt	LGPL
 * @version    ##VERSION##, ##DATE##
 **************************************************************************************

--- a/unitTests/bootstrap.php
+++ b/unitTests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * $Id: bootstrap.php 2892 2011-08-14 15:11:50Z markbaker@phpexcel.net $
  *
- * @copyright   Copyright (C) 2011-2014 PHPExcel. All rights reserved.
+ * @copyright   Copyright (C) 2011-2015 PHPExcel. All rights reserved.
  * @package     PHPExcel
  * @subpackage  PHPExcel Unit Tests
  * @author      Mark Baker


### PR DESCRIPTION
* Several files had copyright years "2006 - 2014" instead of "2006 - 2015"
* URL "http://www.codeplex.com/PHPExcel" changed to "https://github.com/PHPOffice/PHPExcel"