### PR TITLE
Fixed missing renames of writeRelationShip (from _writeRelationShip)

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Rels.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Rels.php
@@ -88,7 +88,7 @@ class PHPExcel_Writer_Excel2007_Rels extends PHPExcel_Writer_Excel2007_WriterPar
         );
         // a custom UI in workbook ?
         if ($pPHPExcel->hasRibbon()) {
-            $this->_writeRelationShip(
+            $this->writeRelationShip(
                 $objWriter,
                 5,
                 'http://schemas.microsoft.com/office/2006/relationships/ui/extensibility',
@@ -162,7 +162,7 @@ class PHPExcel_Writer_Excel2007_Rels extends PHPExcel_Writer_Excel2007_WriterPar
         // Relationships for vbaProject if needed
         // id : just after the last sheet
         if ($pPHPExcel->hasMacros()) {
-            $this->_writeRelationShip(
+            $this->writeRelationShip(
                 $objWriter,
                 ($i + 1 + 3),
                 'http://schemas.microsoft.com/office/2006/relationships/vbaProject',


### PR DESCRIPTION
Writing a Excel2007 file with macro leads to an undefined call to _writeRelationShip. This commit fixes the issue. Can you add it into the current branch?