### PR TITLE
Worksheet title invalid character check comparison

### DIFF
--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -447,7 +447,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
     private static function checkSheetTitle($pValue)
     {
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ]
-        if (str_replace(self::$invalidCharacters, '', $pValue) !== $pValue) {
+        if (str_replace(self::$invalidCharacters, '', $pValue) != $pValue) {
             throw new PHPExcel_Exception('Invalid character found in sheet title');
         }
 


### PR DESCRIPTION
Changed the comparison operator in Worksheet.php `_checkSheetTitle()` method from !== to !=, otherwise using an integer as a worksheet name throws this exception.