### PR TITLE
Prevent Formula Calculations in Charts

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -44,8 +44,11 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
         } else {
             $objWriter = new PHPExcel_Shared_XMLWriter(PHPExcel_Shared_XMLWriter::STORAGE_MEMORY);
         }
-        //    Ensure that data series values are up-to-date before we save
-        $pChart->refresh();
+
+        // Ensure that data series values are up-to-date before we save
+        if ($this->getParentWriter()->getPreCalculateFormulas()) {
+            $pChart->refresh();
+        }
 
         // XML header
         $objWriter->startDocument('1.0', 'UTF-8', 'yes');


### PR DESCRIPTION
Added check to ignore data series formulas if preCalculateFormulas is not true. 

This was inspired by question I asked on StackOverflow: http://stackoverflow.com/questions/33554126/treat-a-formula-like-any-other-text-value-when-exporting-to-excel

Thanks for your help and the great library @MarkBaker 