### PR TITLE
Several simple bug fixes

### DIFF
--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -438,7 +438,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
             $ole = new PHPExcel_Shared_OLERead();
 
             // get excel data
-            $res = $ole->read($pFilename);
+            $ole->read($pFilename);
             return true;
         } catch (PHPExcel_Exception $e) {
             return false;
@@ -1287,7 +1287,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
         // OLE reader
         $ole = new PHPExcel_Shared_OLERead();
         // get excel data,
-        $res = $ole->read($pFilename);
+        $ole->read($pFilename);
         // Get workbook data: workbook stream + sheet streams
         $this->data = $ole->getStream($ole->wrkbook);
         // Get summary information data

--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -115,7 +115,7 @@ class PHPExcel_Shared_String
             "\x1B :"  => chr(10),
             "\x1B ;"  => chr(11),
             "\x1B <"  => chr(12),
-            "\x1B :"  => chr(13),
+            "\x1B ="  => chr(13),
             "\x1B >"  => chr(14),
             "\x1B ?"  => chr(15),
             "\x1B!0"  => chr(16),

--- a/Classes/PHPExcel/Writer/Excel5/Parser.php
+++ b/Classes/PHPExcel/Writer/Excel5/Parser.php
@@ -198,13 +198,13 @@ class PHPExcel_Writer_Excel5_Parser
             'ptgRefNV'     => 0x4C,
             'ptgAreaNV'    => 0x4D,
             'ptgMemAreaNV' => 0x4E,
-            'ptgMemNoMemN' => 0x4F,
+            'ptgMemNoMemNV'=> 0x4F,
             'ptgFuncCEV'   => 0x58,
             'ptgNameXV'    => 0x59,
             'ptgRef3dV'    => 0x5A,
             'ptgArea3dV'   => 0x5B,
             'ptgRefErr3dV' => 0x5C,
-            'ptgAreaErr3d' => 0x5D,
+            'ptgAreaErr3dV'=> 0x5D,
             'ptgArrayA'    => 0x60,
             'ptgFuncA'     => 0x61,
             'ptgFuncVarA'  => 0x62,
@@ -220,13 +220,13 @@ class PHPExcel_Writer_Excel5_Parser
             'ptgRefNA'     => 0x6C,
             'ptgAreaNA'    => 0x6D,
             'ptgMemAreaNA' => 0x6E,
-            'ptgMemNoMemN' => 0x6F,
+            'ptgMemNoMemNA'=> 0x6F,
             'ptgFuncCEA'   => 0x78,
             'ptgNameXA'    => 0x79,
             'ptgRef3dA'    => 0x7A,
             'ptgArea3dA'   => 0x7B,
             'ptgRefErr3dA' => 0x7C,
-            'ptgAreaErr3d' => 0x7D
+            'ptgAreaErr3dA'=> 0x7D
         );
 
         // Thanks to Michael Meeks and Gnumeric for the initial arg values.


### PR DESCRIPTION
This PR contains three commits, each containing a small bug fix so they can be cherry-picked separately if needed.

1. Classes/PHPExcel/Shared/String.php contained a duplicate array key referencing an ANSI escape code - the `:` should be a `=`, assuming it's meant to follow the same pattern as other sequences with the same array.
2. Some excel function codes in Classes/PHPExcel/Writer/Excel5/Parser.php were duplicated. In every case the dulicates were missing a final char, according to references I found.
3. Two function calls stored a value returned from a function call returning void, and the local vars were not used anyway.

I did these against the 1.8 branch as instructed by the readme, so I hope that's still correct.

These errors were flagged by the static analyser in PHPStorm 10 - there are many, many others it spotted - these are really low-hanging fruit in bug tracking terms, no particular subtlety involved!