### PR TITLE
Fix `composer.json` schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "http://phpexcel.codeplex.com",
     "type": "library",
-    "license": "LGPL",
+    "license": "LGPL-2.0",
     "authors": [
         {
             "name": "Maarten Balliauw",
@@ -26,9 +26,12 @@
         "ext-xml": "*",
         "ext-xmlwriter": "*"
     },
-    "recommend": {
+    "suggest": {
         "ext-zip": "*",
-        "ext-gd2": "*"
+        "ext-gd2": "*",
+        "mpdf/mpdf": "In order to export to PDF through mPDF library",
+        "tecnickcom/tcpdf": "In order to export to PDF through TCPDF library",
+        "dompdf/dompdf": "In order to export to PDF through DOMPDF library"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- Replace wrong SPDX licence `LGPL` by `LGPL-2.0`
- Replace wrong property `recommend` by `suggest`
- Add `mpdf/mpdf`, `tecnickcom/tcpdf` and `dompdf/dompdf` as suggested dependencies
