### PR TITLE
Small fixes and changes

### DIFF
--- a/Classes/PHPExcel/CachedObjectStorage/MemoryGZip.php
+++ b/Classes/PHPExcel/CachedObjectStorage/MemoryGZip.php
@@ -39,7 +39,7 @@ class PHPExcel_CachedObjectStorage_MemoryGZip extends PHPExcel_CachedObjectStora
         if ($this->currentCellIsDirty && !empty($this->currentObjectID)) {
             $this->currentObject->detach();
 
-            $this->cellCache[$this->currentObjectID] = gzdeflate(serialize($this->currentObject));
+            $this->cellCache[$this->currentObjectID] = gzdeflate(serialize($this->currentObject), 9);
             $this->currentCellIsDirty = false;
         }
         $this->currentObjectID = $this->currentObject = null;

--- a/Classes/PHPExcel/CachedObjectStorage/PHPTemp.php
+++ b/Classes/PHPExcel/CachedObjectStorage/PHPTemp.php
@@ -179,7 +179,7 @@ class PHPExcel_CachedObjectStorage_PHPTemp extends PHPExcel_CachedObjectStorage_
      */
     public function __construct(PHPExcel_Worksheet $parent, $arguments)
     {
-        $this->memoryCacheSize = (isset($arguments['memoryCacheSize'])) ? $arguments['memoryCacheSize'] : '1MB';
+        $this->memoryCacheSize = (isset($arguments['memoryCacheSize'])) ? $arguments['memoryCacheSize'] : '1024';
 
         parent::__construct($parent);
         if (is_null($this->fileHandle)) {

--- a/Classes/PHPExcel/CachedObjectStorageFactory.php
+++ b/Classes/PHPExcel/CachedObjectStorageFactory.php
@@ -86,7 +86,7 @@ class PHPExcel_CachedObjectStorageFactory
                                                     ),
         self::cache_igbinary                => array(
                                                     ),
-        self::cache_to_phpTemp              => array( 'memoryCacheSize' => '1MB'
+        self::cache_to_phpTemp              => array( 'memoryCacheSize' => '1024' // must be in bytes
                                                     ),
         self::cache_to_discISAM             => array( 'dir'             => null
                                                     ),

--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -5457,7 +5457,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
                     unset($space2, $space3, $space4, $space5);
                     break;
                 case 'tArray': // array constant
-                    $constantArray = self::_readBIFF8ConstantArray($additionalData);
+                    $constantArray = self::readBIFF8ConstantArray($additionalData);
                     $formulaStrings[] = $space1 . $space0 . $constantArray['value'];
                     $additionalData = substr($additionalData, $constantArray['size']); // bite of chunk of additional data
                     unset($space0, $space1);
@@ -7209,7 +7209,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
         for ($r = 1; $r <= $nr + 1; ++$r) {
             $items = array();
             for ($c = 1; $c <= $nc + 1; ++$c) {
-                $constant = self::_readBIFF8Constant($arrayData);
+                $constant = self::readBIFF8Constant($arrayData);
                 $items[] = $constant['value'];
                 $arrayData = substr($arrayData, $constant['size']);
                 $size += $constant['size'];


### PR DESCRIPTION
- memoryCacheSize must be expressed in bytes according documentation.
-Typo fixes.
- For save memory using gzip cache, choosing level 9 allow avoid no memory errors.
