### PR TITLE
Fix bug on HTML.php where PHPExcel_Reader_Exception is not constructe…

### DIFF
--- a/Classes/PHPExcel/Reader/HTML.php
+++ b/Classes/PHPExcel/Reader/HTML.php
@@ -494,7 +494,7 @@ class PHPExcel_Reader_HTML extends PHPExcel_Reader_Abstract implements PHPExcel_
         //    Reload the HTML file into the DOM object
         $loaded = $dom->loadHTML(mb_convert_encoding($this->securityScanFile($pFilename), 'HTML-ENTITIES', 'UTF-8'));
         if ($loaded === false) {
-            throw new PHPExcel_Reader_Exception('Failed to load ', $pFilename, ' as a DOM Document');
+            throw new PHPExcel_Reader_Exception('Failed to load '. $pFilename. ' as a DOM Document');
         }
 
         //    Discard white space


### PR DESCRIPTION
### Fix a bug on PHPExcel_Reader_Exception. 

We **should** pass in a string as argument.

It used to cause exception with message  ""exception exception 'TypehintViolationException' with message 'Argument 3 passed to Exception::__construct() must implement interface __SystemLib\Throwable, string given TAAL[BLAME_frame]"