### PR TITLE
Adding float cast to MOD function

### DIFF
--- a/Classes/PHPExcel/Calculation/MathTrig.php
+++ b/Classes/PHPExcel/Calculation/MathTrig.php
@@ -705,7 +705,7 @@ class PHPExcel_Calculation_MathTrig
             return $b + fmod($a, abs($b));
         }
 
-        return fmod($a, $b);
+        return fmod((float)$a, (float)$b);
     }
 
 


### PR DESCRIPTION
If $a or $b are not strings, you can get an error that fmod needs param 1 ($a) to be of type double. 
MS Excel does not fall over when you insert an empty string in MOD, so I'm guessing PHPExcel should do the same?
