### PR TITLE
Fixes freezes on parsing conditional formatting with longs references…

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -309,7 +309,7 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 
         // Sadly, some 3rd party xlsx generators don't use consistent case for filenaming
         //    so we need to load case-insensitively from the zip file
-        
+
         // Apache POI fixes
         $contents = $archive->getFromIndex(
             $archive->locateName($fileName, ZIPARCHIVE::FL_NOCASE)
@@ -960,9 +960,7 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
                                     }
 
                                     // Extract all cell references in $ref
-                                    foreach (PHPExcel_Cell::extractAllCellReferencesInRange($ref) as $reference) {
-                                        $docSheet->getStyle($reference)->setConditionalStyles($conditionalStyles);
-                                    }
+                                    $docSheet->getStyle($ref)->setConditionalStyles($conditionalStyles);
                                 }
                             }
 


### PR DESCRIPTION
It should fix freezes on parsing conditional formatting with longs references like `$A1:1048576` by just copying it directly.

This bugs affects too if references is described as $A:$A.

Solves https://github.com/PHPOffice/PHPExcel/issues/575

Note: I should tell that all this phpunit erros are not my fault. I tried it locally too and I get 141 errors, after this fix, it continues in 141 errors. :)

@MarkBaker 