### PR TITLE
Replaced x: NameSpace

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -320,7 +320,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
             );
         }
 
-        return $contents;
+        //according to https://msdn.microsoft.com/en-us/library/office/gg278316.aspx
+        //.xlsx includes NameSpace x: this type of files doesn't work without replace
+        return str_replace('x:', '', $contents);
     }
 
 


### PR DESCRIPTION
According https://msdn.microsoft.com/en-us/library/office/gg278316.aspx .xlsx file includes x: namespace. With standard simplexml_load_string this files doesn't parse properly