### PR TITLE
Bug fix: c:max and c:min elements shall NOT be inside c:orientation elements

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -540,8 +540,6 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
         }
 
         $objWriter->startElement('c:scaling');
-        $objWriter->startElement('c:orientation');
-        $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('orientation'));
 
         if (!is_null($xAxis->getAxisOptionsProperty('maximum'))) {
             $objWriter->startElement('c:max');
@@ -554,6 +552,10 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
             $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('minimum'));
             $objWriter->endElement();
         }
+
+        $objWriter->startElement('c:orientation');
+        $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('orientation'));
+
 
         $objWriter->endElement();
         $objWriter->endElement();


### PR DESCRIPTION
Bug fix: c:max and c:min elements shall not be inside c:orientation elements. 

They shall be placed inside c:scaling element. Otherwise these values are ignored by Excel and Libreoffice.