### PR TITLE
Throw InvalidArgumentException in case getint4d fails

### DIFF
--- a/Classes/PHPExcel/Shared/OLERead.php
+++ b/Classes/PHPExcel/Shared/OLERead.php
@@ -306,6 +306,18 @@ class PHPExcel_Shared_OLERead
         // FIX: represent numbers correctly on 64-bit system
         // http://sourceforge.net/tracker/index.php?func=detail&aid=1487372&group_id=99160&atid=623334
         // Hacked by Andreas Rehm 2006 to ensure correct result of the <<24 block on 32 and 64bit systems
+        if(!isset($data[$pos + 3])){
+            $error_message = 'EXCEPTION (InvalidBlockException) :: CORRUPT BLOCKS IN XLS FILE'."\nCallStack: \n";
+            foreach(debug_backtrace() as $ik=>$kk){
+                $message = '';
+                foreach($kk as $ikk=>$kkk){
+                  if($ikk=='object' || $ikk=='args' || $ikk=='type') continue;
+                  $message .= ''.$ikk.'=>['.$kkk.']'." ";
+                }
+                if(!empty($message)) $error_message.=$message."\n";
+            }
+            throw new InvalidArgumentException($error_message);
+        }//if
         $_or_24 = ord($data[$pos + 3]);
         if ($_or_24 >= 128) {
             // negative number


### PR DESCRIPTION
I have noticed a case where function "private static function getInt4d($data, $pos)" in OLERead.php file fails to read  4 bytes of data from corrupted block. It is not feasible to make changes everywhere, hence we are throwing InvalidArgumentException which will make sure that we do not end up with infinite looping in any situation. Please parse sample files attached in the zip archive.

[test.zip](https://github.com/PHPOffice/PHPExcel/files/208217/test.zip)


