### PR TITLE
Do not overwrite separator if no separator is defined in file

### DIFF
--- a/Classes/PHPExcel/Reader/CSV.php
+++ b/Classes/PHPExcel/Reader/CSV.php
@@ -170,8 +170,10 @@ class PHPExcel_Reader_CSV extends PHPExcel_Reader_Abstract implements PHPExcel_R
 
         if ((strlen(trim($line)) == 5) && (strpos($line, 'sep=') !== 0)) {
             return $this->skipBOM();
+        }elseif((strlen(trim($line)) == 5) && (strpos($line, 'sep=') === 0)){
+            $this->delimiter = substr($line, 4, 1);
+            return;
         }
-        $this->delimiter = substr($line, 4, 1);
     }
 
     /**

--- a/Classes/PHPExcel/Reader/CSV.php
+++ b/Classes/PHPExcel/Reader/CSV.php
@@ -170,7 +170,7 @@ class PHPExcel_Reader_CSV extends PHPExcel_Reader_Abstract implements PHPExcel_R
 
         if ((strlen(trim($line)) == 5) && (strpos($line, 'sep=') !== 0)) {
             return $this->skipBOM();
-        }elseif((strlen(trim($line)) == 5) && (strpos($line, 'sep=') === 0)){
+        } elseif ((strlen(trim($line)) == 5) && (strpos($line, 'sep=') === 0)) {
             $this->delimiter = substr($line, 4, 1);
             return;
         }


### PR DESCRIPTION
Given a csv file 

                Johnathan, Danson, Whosville

and reading it like 

                $objReader = PHPExcel_IOFactory::createReader('CSV');
                $objReader->setDelimiter(',');

would otherwise result in (using [] to denote cells)

                [John][th][n, D][nson, Whosville]