### PR TITLE
Fix a fatal error when PHPExcel_RichText tries to extract container cell's font

### DIFF
--- a/Classes/PHPExcel/RichText.php
+++ b/Classes/PHPExcel/RichText.php
@@ -50,7 +50,7 @@ class PHPExcel_RichText implements PHPExcel_IComparable
             // Add cell text and style
             if ($pCell->getValue() != "") {
                 $objRun = new PHPExcel_RichText_Run($pCell->getValue());
-                $objRun->setFont(clone $pCell->getParent()->getStyle($pCell->getCoordinate())->getFont());
+                $objRun->setFont(clone $pCell->getWorksheet()->getStyle($pCell->getCoordinate())->getFont());
                 $this->addText($objRun);
             }
 


### PR DESCRIPTION
`PHPExcel_RichText` tries to extract container cell's font via `PHPExcel_Cell->getParent()->getStyle(...)`, which crashes because `getStyle()` is a method on the worksheet, but `getParent()` does not return a worksheet. Changing it to `PHPExcel_Cell->getWorksheet()->getStyle(...)` fixes the problem.
