### PR TITLE
Fix: remove extra bracket from isErr

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -379,7 +379,7 @@ class Functions
     {
         $value = self::flattenSingleValue($value);
 
-        return self::isError($value) && (!self::isNa(($value));
+        return self::isError($value) && (!self::isNa($value));
     }
 
 


### PR DESCRIPTION
syntax error, unexpected ';' in isErr