### PR TITLE
Fix: Plot series values not detect DataSeries type

### DIFF
--- a/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
@@ -408,7 +408,7 @@ class Chart extends WriterPart
      *
      * @param  \PHPExcel\Shared\XMLWriter $objWriter XML Writer
      * @param  PlotArea $plotArea
-     * @param  PHPExcel_Chart_Title $xAxisLabel
+     * @param  \PHPExcel\Chart\Title $xAxisLabel
      * @param  string $groupType Chart type
      * @param  string $id1
      * @param  string $id2
@@ -529,8 +529,8 @@ class Chart extends WriterPart
      * Write Value Axis
      *
      * @param  \PHPExcel\Shared\XMLWriter $objWriter XML Writer
-     * @param  PHPExcel_Chart_PlotArea $plotArea
-     * @param  PHPExcel_Chart_Title $yAxisLabel
+     * @param  \PHPExcel\Chart\PlotArea $plotArea
+     * @param  \PHPExcel\Chart\Title $yAxisLabel
      * @param  string $groupType Chart type
      * @param  string $id1
      * @param  string $id2
@@ -1015,7 +1015,7 @@ class Chart extends WriterPart
     /**
      * Get the data series type(s) for a chart plot series
      *
-     * @param  PHPExcel_Chart_PlotArea $plotArea
+     * @param  \PHPExcel\Chart\PlotArea $plotArea
      *
      * @return  string|array
      * @throws  \PHPExcel\Writer\Exception
@@ -1260,10 +1260,9 @@ class Chart extends WriterPart
      * @param  DataSeriesValues $plotSeriesValues
      * @param  \PHPExcel\Shared\XMLWriter $objWriter XML Writer
      * @param  string $groupType Type of plot for dataseries
-     * @param  string $dataType Datatype of series values
-     * @param  \PHPExcel\Worksheet $pSheet
+     * @param bool|string $dataType Datatype of series values
+     * @internal param \PHPExcel\Worksheet $pSheet
      *
-     * @throws  \PHPExcel\Writer\Exception
      */
     private function writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataType = false)
     {

--- a/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
@@ -44,8 +44,9 @@ class Chart extends WriterPart
      *
      * @param  \PHPExcel\Chart $pChart
      *
-     * @return  string            XML Output
-     * @throws  \PHPExcel\Writer\Exception
+     * @param bool $calculateCellValues
+     * @return string XML Output
+     * @throws \PHPExcel\Writer\Exception
      */
     public function writeChart(\PHPExcel\Chart $pChart = null, $calculateCellValues = true)
     {
@@ -220,11 +221,14 @@ class Chart extends WriterPart
      * @param  PlotArea $plotArea
      * @param  Title $xAxisLabel
      * @param  Title $yAxisLabel
-     * @param  Axis $xAxis
-     * @param  Axis $yAxis
      * @param  \PHPExcel\Shared\XMLWriter $objWriter XML Writer
      *
-     * @throws  \PHPExcel\Writer\Exception
+     * @param \PHPExcel\Worksheet $pSheet
+     * @param  Axis $xAxis
+     * @param  Axis $yAxis
+     * @param GridLines $majorGridlines
+     * @param GridLines $minorGridlines
+     * @throws \PHPExcel\Writer\Exception
      */
     private function writePlotArea(PlotArea $plotArea, Title $xAxisLabel, Title $yAxisLabel, $objWriter, \PHPExcel\Worksheet $pSheet, Axis $xAxis, Axis $yAxis, GridLines $majorGridlines, GridLines $minorGridlines)
     {
@@ -414,7 +418,8 @@ class Chart extends WriterPart
      * @param  string $id2
      * @param  boolean $isMultiLevelSeries
      *
-     * @throws  \PHPExcel\Writer\Exception
+     * @param $xAxis
+     * @param $yAxis
      */
     private function writeCategoryAxis($objWriter, PlotArea $plotArea, $xAxisLabel, $groupType, $id1, $id2, $isMultiLevelSeries, $xAxis, $yAxis)
     {
@@ -536,7 +541,10 @@ class Chart extends WriterPart
      * @param  string $id2
      * @param  boolean $isMultiLevelSeries
      *
-     * @throws  \PHPExcel\Writer\Exception
+     * @param $xAxis
+     * @param $yAxis
+     * @param $majorGridlines
+     * @param $minorGridlines
      */
     private function writeValueAxis($objWriter, PlotArea $plotArea, $yAxisLabel, $groupType, $id1, $id2, $isMultiLevelSeries, $xAxis, $yAxis, $majorGridlines, $minorGridlines)
     {

--- a/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Excel2007/Chart.php
@@ -1191,7 +1191,7 @@ class Chart extends WriterPart
                     $objWriter->startElement('c:cat');
                 }
 
-                $this->writePlotSeriesValues($plotSeriesCategory, $objWriter, $groupType, 'str');
+                $this->writePlotSeriesValues($plotSeriesCategory, $objWriter, $groupType);
                 $objWriter->endElement();
             }
 
@@ -1205,7 +1205,7 @@ class Chart extends WriterPart
                     $objWriter->startElement('c:val');
                 }
 
-                $this->writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, 'num');
+                $this->writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType);
                 $objWriter->endElement();
             }
 
@@ -1265,10 +1265,22 @@ class Chart extends WriterPart
      *
      * @throws  \PHPExcel\Writer\Exception
      */
-    private function writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataType = 'str')
+    private function writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataType = false)
     {
         if (is_null($plotSeriesValues)) {
             return;
+        }
+        
+        if (!$dataType) {
+            switch ($plotSeriesValues->getDataType()) {
+                case DataSeriesValues::DATASERIES_TYPE_NUMBER:
+                    $dataType = 'num';
+                    break;
+                case DataSeriesValues::DATASERIES_TYPE_STRING:
+                default:
+                    $dataType = 'str';
+                    break;
+            }
         }
 
         if ($plotSeriesValues->isMultiLevelSeries()) {

--- a/unitTests/Classes/src/Chart/PlotSeriesValuesTest.php
+++ b/unitTests/Classes/src/Chart/PlotSeriesValuesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace PHPExcel\Chart;
+
+use PHPExcel;
+use PHPExcel\Chart;
+use PHPExcel\Exception;
+use PHPExcel\IOFactory;
+
+class PlotSeriesValuesTest extends \PHPUnit_Framework_TestCase
+{
+    private $dataTypeValuesSets = [
+        [
+            'dataSeries' => DataSeriesValues::DATASERIES_TYPE_STRING,
+            'xAxis' => DataSeriesValues::DATASERIES_TYPE_NUMBER
+        ],
+        [
+            'dataSeries' => DataSeriesValues::DATASERIES_TYPE_NUMBER,
+            'xAxis' => DataSeriesValues::DATASERIES_TYPE_STRING
+        ],
+        [
+            'dataSeries' => DataSeriesValues::DATASERIES_TYPE_NUMBER,
+            'xAxis' => DataSeriesValues::DATASERIES_TYPE_NUMBER
+        ],
+        [
+            'dataSeries' => DataSeriesValues::DATASERIES_TYPE_STRING,
+            'xAxis' => DataSeriesValues::DATASERIES_TYPE_STRING
+        ],
+    ];
+
+    public function testPlotSeriesValuesDataType()
+    {
+        $objWriter = IOFactory::createWriter(new PHPExcel\Spreadsheet, 'Excel2007');
+        foreach ($this->dataTypeValuesSets as $dataSeriesTypes) {
+            $chart = $this->generateChart($dataSeriesTypes['dataSeries'], $dataSeriesTypes['xAxis']);
+            $xmlString = $objWriter->getWriterPart('Chart')->writeChart($chart);
+            $this->plotSeriesValuesDataTypeXmlCheck($xmlString, $dataSeriesTypes['dataSeries']);
+        }
+    }
+
+    /**
+     * Generate simple fake line Chart
+     * @param string $dataSeriesType
+     * @param string $xAxisTickType
+     * @return Chart
+     * @internal param string $dataSeriesType
+     */
+    protected function generateChart(
+        $dataSeriesType = DataSeriesValues::DATASERIES_TYPE_NUMBER,
+        $xAxisTickType = DataSeriesValues::DATASERIES_TYPE_NUMBER
+
+    ) {
+        try {
+            $layout = new Layout();
+            $axisLabels = new Title(null, $layout);
+            $Axis = new Axis();
+            $majorGridlines = new GridLines();
+            $dataSeriesLabels = array(new DataSeriesValues,);
+
+            $dataSeriesValues = array(
+                new DataSeriesValues($dataSeriesType)
+            );
+
+            $xAxisTickValues = array(
+                new DataSeriesValues($xAxisTickType),
+            );
+
+            $series = new DataSeries(
+                DataSeries::TYPE_LINECHART,        // plotType
+                DataSeries::GROUPING_STANDARD,    // plotGrouping
+                range(0, mt_rand(0, 200)),            // plotOrder
+                $dataSeriesLabels,                                // plotLabel
+                $xAxisTickValues,                                // plotCategory
+                $dataSeriesValues//,								// plotValues
+            );
+            $plotArea = new PlotArea($layout, array($series));
+            $chart = new Chart(
+                'chart',        // name
+                new Title(null, $layout),            // title
+                new Legend(Legend::POSITION_RIGHT, $layout),        // legend
+                $plotArea,
+                true,
+                0,
+                $axisLabels,
+                $axisLabels,
+                $Axis,
+                $Axis,
+                $majorGridlines
+            );
+            $chart->setWorksheet(new \PHPExcel\Worksheet());
+            return $chart;
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * @param $xmlString
+     * @param $type
+     */
+    private function plotSeriesValuesDataTypeXmlCheck($xmlString, $type)
+    {
+        switch ($type) {
+            case DataSeriesValues::DATASERIES_TYPE_NUMBER:
+                $dataType = 'num';
+                break;
+            case DataSeriesValues::DATASERIES_TYPE_STRING:
+            default:
+                $dataType = 'str';
+                break;
+        }
+
+        $dom = new \DOMDocument();
+        $dom->loadXML($xmlString);
+        $xpath = new \DOMXpath($dom);
+        $path = '/c:chartSpace/c:chart/c:plotArea/c:lineChart/c:ser/c:val/c:' . $dataType . 'Ref';
+        $nodeList = $xpath->query($path);
+        $this->assertTrue((bool)$nodeList->length, 'Path: '.$path.' failed. DataSeries Type: '.$type);
+    }
+}


### PR DESCRIPTION
**Excel2007** strongly adheres to **OpenXML** specification. What is usually good for **OpenOffice** not always good for **Excel2007**.  So dataType should be taken from DataSeriesValues (not to be hardcoded in class  as it is)

Example: if chart's **xAxisTickValues** contains numbers then generated **c:strRef** (as it was) will be wrong. **OpenOffice** feels good, but **Excel2007** gives the error

> Removed Part: /xl/drawings/drawing1.xml part. (Drawing shape).

as it should be c:numRef