### PR TITLE
Make PHPToExcel use instance of DateTimeInterface rather than DateTime

### DIFF
--- a/Classes/PHPExcel/Shared/Date.php
+++ b/Classes/PHPExcel/Shared/Date.php
@@ -188,7 +188,7 @@ class PHPExcel_Shared_Date
             0;
 
         $retValue = false;
-        if ((is_object($dateValue)) && ($dateValue instanceof DateTime)) {
+        if ((is_object($dateValue)) && ($dateValue instanceof DateTimeInterface)) {
             $dateValue->add(new DateInterval('PT' . $timezoneAdjustment . 'S'));
             $retValue = self::FormattedPHPToExcel($dateValue->format('Y'), $dateValue->format('m'), $dateValue->format('d'), $dateValue->format('H'), $dateValue->format('i'), $dateValue->format('s'));
         } elseif (is_numeric($dateValue)) {


### PR DESCRIPTION
This will allow the use of any object implementing `DateTimeInterface`.

https://github.com/PHPOffice/PHPExcel/issues/907