### PR TITLE
DatetimeImmutable object should be treated as Datetime

### DIFF
--- a/Classes/PHPExcel/Calculation/DateTime.php
+++ b/Classes/PHPExcel/Calculation/DateTime.php
@@ -98,7 +98,7 @@ class PHPExcel_Calculation_DateTime
                 (PHPExcel_Calculation_Functions::getCompatibilityMode() == PHPExcel_Calculation_Functions::COMPATIBILITY_GNUMERIC)) {
                 return PHPExcel_Calculation_Functions::VALUE();
             }
-            if ((is_object($dateValue)) && ($dateValue instanceof DateTime)) {
+            if ((is_object($dateValue)) && ($dateValue instanceof DateTimeInterface)) {
                 $dateValue = PHPExcel_Shared_Date::PHPToExcel($dateValue);
             } else {
                 $saveReturnDateType = PHPExcel_Calculation_Functions::getReturnDateType();

--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -50,7 +50,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
             $value = PHPExcel_Shared_String::SanitizeUTF8($value);
         } elseif (is_object($value)) {
             // Handle any objects that might be injected
-            if ($value instanceof DateTime) {
+            if ($value instanceof DateTimeInterface) {
                 $value = $value->format('Y-m-d H:i:s');
             } elseif (!($value instanceof PHPExcel_RichText)) {
                 $value = (string) $value;

--- a/Classes/PHPExcel/Shared/Date.php
+++ b/Classes/PHPExcel/Shared/Date.php
@@ -188,7 +188,7 @@ class PHPExcel_Shared_Date
             0;
 
         $retValue = false;
-        if ((is_object($dateValue)) && ($dateValue instanceof DateTime)) {
+        if ((is_object($dateValue)) && ($dateValue instanceof DateTimeInterface)) {
             $dateValue->add(new DateInterval('PT' . $timezoneAdjustment . 'S'));
             $retValue = self::FormattedPHPToExcel($dateValue->format('Y'), $dateValue->format('m'), $dateValue->format('d'), $dateValue->format('H'), $dateValue->format('i'), $dateValue->format('s'));
         } elseif (is_numeric($dateValue)) {

--- a/unitTests/Classes/PHPExcel/Shared/DateTest.php
+++ b/unitTests/Classes/PHPExcel/Shared/DateTest.php
@@ -74,6 +74,16 @@ class DateTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedResult, $result, null, 1E-5);
     }
 
+    public function testDateTimeImmutableShouldBeConsideredAsDateTime()
+    {
+        $excelDate = new PHPExcel_Shared_Date();
+
+        $immutableDateTime = new DateTimeImmutable();
+        $retValue = $excelDate->PHPToExcel($immutableDateTime);
+
+        $this->assertNotEquals(false, $retValue);
+    }
+
     public function providerDateTimePHPToExcel1900()
     {
         return new testDataFileIterator('rawTestData/Shared/DateTimePHPToExcel1900.data');


### PR DESCRIPTION
In our project, we often use  `DatetimeImmutable` object in many
situations where immutable `DateTime` object is considered as risky.

But in this project, for instance the
[PHPExcel_Shared_Date::PHPToExcel($dateValue)]
(https://github.com/PHPOffice/PHPExcel/blob/1.8/Classes/PHPExcel/Shared/Date.php#L191)
method verifies $dateValue as DateTime instead of DateTimeInterface.
Therefore, the method return false when we pass DateTimeImmutable object.

 - Changed `DateTime` to `DateTimeInterface` in type checking conditions