### PR TITLE
Recover from non-readable images

### DIFF
--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -1065,7 +1065,14 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
                             // need check because some blip types are not supported by Escher reader such as EMF
                             if ($blip = $BSE->getBlip()) {
-                                $ih = imagecreatefromstring($blip->getData());
+
+                                // check if we can actually create the image... no support for bmp
+                                try {
+                                    $ih = imagecreatefromstring($blip->getData());
+                                } catch (Exception $exception) {
+                                    break;
+                                }
+                                
                                 $drawing = new PHPExcel_Worksheet_MemoryDrawing();
                                 $drawing->setImageResource($ih);
 


### PR DESCRIPTION
Having problem reading excel files when there's a bmp image, or other non-readable image.
This will ignore those picture objects instead of throwing an exception and making parsing not possible.