### PR TITLE
ComputerTinker Patch Rollup 2016-06-17

### DIFF
--- a/Classes/PHPExcel/Chart/DataSeriesValues.php
+++ b/Classes/PHPExcel/Chart/DataSeriesValues.php
@@ -288,13 +288,17 @@ class PHPExcel_Chart_DataSeriesValues
     {
         if ($this->dataSource !== null) {
             $calcEngine = PHPExcel_Calculation::getInstance($worksheet->getParent());
-            $newDataValues = PHPExcel_Calculation::unwrapResult(
-                $calcEngine->_calculateFormulaValue(
-                    '='.$this->dataSource,
-                    null,
-                    $worksheet->getCell('A1')
-                )
-            );
+            
+            $aryDataSources = explode(',', $this->dataSource);
+            if ($aryDataSources === false || empty($aryDataSources))
+              $aryDataSources = array($this->dataSource);
+            $newDataValues = array();
+            foreach ($aryDataSources as $cDataSource) {
+                $newDataValues = array_merge($newDataValues, PHPExcel_Calculation::unwrapResult(
+                    $calcEngine->_calculateFormulaValue('=' . $cDataSource, null, $worksheet->getCell('A1'))
+                ));
+            }
+            
             if ($flatten) {
                 $this->dataValues = PHPExcel_Calculation_Functions::flattenArray($newDataValues);
                 foreach ($this->dataValues as &$dataValue) {
@@ -304,27 +308,28 @@ class PHPExcel_Chart_DataSeriesValues
                 }
                 unset($dataValue);
             } else {
-                $cellRange = explode('!', $this->dataSource);
-                if (count($cellRange) > 1) {
-                    list(, $cellRange) = $cellRange;
-                }
-
-                $dimensions = PHPExcel_Cell::rangeDimension(str_replace('$', '', $cellRange));
-                if (($dimensions[0] == 1) || ($dimensions[1] == 1)) {
-                    $this->dataValues = PHPExcel_Calculation_Functions::flattenArray($newDataValues);
-                } else {
-                    $newArray = array_values(array_shift($newDataValues));
-                    foreach ($newArray as $i => $newDataSet) {
-                        $newArray[$i] = array($newDataSet);
+                foreach($aryDataSources as $cDataSource) {
+                    $cellRange = explode('!', $cDataSource);
+                    if (count($cellRange) > 1) {
+                        list(, $cellRange) = $cellRange;
                     }
-
-                    foreach ($newDataValues as $newDataSet) {
-                        $i = 0;
-                        foreach ($newDataSet as $newDataVal) {
-                            array_unshift($newArray[$i++], $newDataVal);
+                    $cellRange = str_replace('$', '', $cellRange[0]);
+                    $dimensions = PHPExcel_Cell::rangeDimension($cellRange);
+                    if (($dimensions[0] == 1) || ($dimensions[1] == 1)) {
+                        $this->dataValues = array_merge($this->dataValues, PHPExcel_Calculation_Functions::flattenArray($newDataValues));
+                    } else {
+                        $newArray = array_values(array_shift($newDataValues));
+                        foreach ($newArray as $i => $newDataSet) {
+                            $newArray[$i] = array($newDataSet);
                         }
+                        foreach ($newDataValues as $newDataSet) {
+                            $i = 0;
+                            foreach ($newDataSet as $newDataVal) {
+                                array_unshift($newArray[$i++], $newDataVal);
+                            }
+                        }
+                        $this->dataValues = array_merge($this->dataValues, $newArray);
                     }
-                    $this->dataValues = $newArray;
                 }
             }
             $this->pointCount = count($this->dataValues);

--- a/Classes/PHPExcel/Style/Color.php
+++ b/Classes/PHPExcel/Style/Color.php
@@ -30,14 +30,31 @@ class PHPExcel_Style_Color extends PHPExcel_Style_Supervisor implements PHPExcel
     /* Colors */
     const COLOR_BLACK      = 'FF000000';
     const COLOR_WHITE      = 'FFFFFFFF';
+    const COLOR_GRAY       = 'FF808080';
+
     const COLOR_RED        = 'FFFF0000';
     const COLOR_DARKRED    = 'FF800000';
-    const COLOR_BLUE       = 'FF0000FF';
-    const COLOR_DARKBLUE   = 'FF000080';
+
     const COLOR_GREEN      = 'FF00FF00';
     const COLOR_DARKGREEN  = 'FF008000';
+
+    const COLOR_BLUE       = 'FF0000FF';
+    const COLOR_DARKBLUE   = 'FF000080';
+
     const COLOR_YELLOW     = 'FFFFFF00';
-    const COLOR_DARKYELLOW = 'FF808000';
+    const COLOR_ORANGE     = 'FFFF8000';
+    const COLOR_LIME       = 'FF80FF00';
+    const COLOR_DARKYELLOW = 'FF808000';  /* AKA Olive */
+
+    const COLOR_CYAN       = 'FF00FFFF';  /* AKA Aqua */
+    const COLOR_GREENTEAL  = 'FF00FF80';
+    const COLOR_BLUETEAL   = 'FF0080FF';
+    const COLOR_TEAL       = 'FF008080';
+
+    const COLOR_FUCHSIA    = 'FFFF00FF';  /* AKA Magenta */
+    const COLOR_REDPURPLE  = 'FFFF0080';
+    const COLOR_BLUEPURPLE = 'FF8000FF';
+    const COLOR_PURPLE     = 'FF800080';
 
     /**
      * Indexed colors array

--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -36,6 +36,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
     const FORMAT_NUMBER_00               = '0.00';
     const FORMAT_NUMBER_COMMA_SEPARATED1 = '#,##0.00';
     const FORMAT_NUMBER_COMMA_SEPARATED2 = '#,##0.00_-';
+    const FORMAT_NUMBER_SCIENTIFIC       = '0.00E+00';
 
     const FORMAT_PERCENTAGE              = '0%';
     const FORMAT_PERCENTAGE_00           = '0.00%';
@@ -66,6 +67,12 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
     const FORMAT_CURRENCY_USD_SIMPLE     = '"$"#,##0.00_-';
     const FORMAT_CURRENCY_USD            = '$#,##0_-';
     const FORMAT_CURRENCY_EUR_SIMPLE     = '[$EUR ]#,##0.00_-';
+
+    const FORMAT_LOG_YESNO               = '"Yes";;"No"';
+    const FORMAT_LOG_YN                  = '"Y";;"N"';
+    const FORMAT_LOG_TRUEFALSE           = '"True";;"False"';
+    const FORMAT_LOG_TF                  = '"T";;"F"';
+    const FORMAT_LOG_ONOFF               = '"On";;"Off"';
 
     /**
      * Excel built-in number formats
@@ -592,6 +599,16 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
         // Convert any other escaped characters to quoted strings, e.g. (\T to "T")
         $format = preg_replace('/(\\\(.))(?=(?:[^"]|"[^"]*")*$)/u', '"${2}"', $format);
 
+        $isLogical = false;
+        if ($format == PHPExcel_Style_NumberFormat::FORMAT_LOG_YESNO ||
+            $format == PHPExcel_Style_NumberFormat::FORMAT_LOG_YN ||
+            $format == PHPExcel_Style_NumberFormat::FORMAT_LOG_TRUEFALSE ||
+            $format == PHPExcel_Style_NumberFormat::FORMAT_LOG_TF ||
+            $format == PHPExcel_Style_NumberFormat::FORMAT_LOG_ONOFF) {
+          
+            $isLogical = true;
+        }
+
         // Get the sections, there can be up to four sections, separated with a semi-colon (but only if not a quoted literal)
         $sections = preg_split('/(;)(?=(?:[^"]|"[^"]*")*$)/u', $format);
 
@@ -641,8 +658,11 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
 
         // Let's begin inspecting the format and converting the value to a formatted string
 
+        if ($isLogical == true) {
+           $value = str_replace('"', '', $format);
+        }
         //  Check for date/time characters (not inside quotes)
-        if (preg_match('/(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)/miu', $format, $matches)) {
+        else if (preg_match('/(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)/miu', $format, $matches)) {
             // datetime format
             self::formatAsDate($value, $format);
         } elseif (preg_match('/%$/', $format)) {

--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -549,9 +549,13 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
     {
         $rowMax = $row;
         $colMax = 'A';
+        $foundChart = false;
+        $foundImage = false;
+
         if ($this->includeCharts) {
             foreach ($pSheet->getChartCollection() as $chart) {
                 if ($chart instanceof PHPExcel_Chart) {
+                    $foundChart = true;
                     $chartCoordinates = $chart->getTopLeftPosition();
                     $chartTL = PHPExcel_Cell::coordinateFromString($chartCoordinates['cell']);
                     $chartCol = PHPExcel_Cell::columnIndexFromString($chartTL[0]);
@@ -567,6 +571,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
         foreach ($pSheet->getDrawingCollection() as $drawing) {
             if ($drawing instanceof PHPExcel_Worksheet_Drawing) {
+                $foundImage = true;
                 $imageTL = PHPExcel_Cell::coordinateFromString($drawing->getCoordinates());
                 $imageCol = PHPExcel_Cell::columnIndexFromString($imageTL[0]);
                 if ($imageTL[1] > $rowMax) {
@@ -578,10 +583,14 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
             }
         }
 
+        if ($foundChart == false && $foundImage == false) {
+            return '';
+        }
+
         $html = '';
         $colMax++;
         while ($row <= $rowMax) {
-            $html .= '<tr>';
+            $html .= '          <tr>';
             for ($col = 'A'; $col != $colMax; ++$col) {
                 $html .= '<td>';
                 $html .= $this->writeImageInCell($pSheet, $col.$row);
@@ -591,7 +600,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
                 $html .= '</td>';
             }
             ++$row;
-            $html .= '</tr>';
+            $html .= '</tr>' . PHP_EOL;
         }
         return $html;
     }
@@ -833,7 +842,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
         // Calculate cell style hashes
         foreach ($this->phpExcel->getCellXfCollection() as $index => $style) {
-            $css['td.style' . $index] = $this->createCSSStyle($style);
+            $css['td.style' . $index . ',a.style' . $index] = $this->createCSSStyle($style);
             $css['th.style' . $index] = $this->createCSSStyle($style);
         }
 
@@ -1019,6 +1028,32 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
         $css['border-left']   = $this->createCSSStyleBorder($pStyle->getLeft());
         $css['border-right']  = $this->createCSSStyleBorder($pStyle->getRight());
 
+        // If all of the various 'border-*' properties are identical, we can use the 'border' property instead in order to be more efficient.
+        if ($css['border-bottom'] == $css['border-top'] &&
+            $css['border-bottom'] == $css['border-left'] &&
+            $css['border-bottom'] == $css['border-right']) {
+
+            $css['border'] = $css['border-bottom'];
+            unset($css['border-bottom'], $css['border-top'], $css['border-left'], $css['border-right']);
+            
+            if ($css['border'] == '') {
+              unset($css['border']);
+            }
+        }
+        else {
+          if ($css['border-bottom'] == '') {
+              unset($css['border-bottom']);
+          }
+          if ($css['border-top'] == '') { 
+              unset($css['border-top']);
+          }
+          if ($css['border-left'] == '') { 
+              unset($css['border-left']);
+          }
+          if ($css['border-right'] == '') { 
+              unset($css['border-right']);
+          }
+        }
         return $css;
     }
 
@@ -1030,11 +1065,16 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
      */
     private function createCSSStyleBorder(PHPExcel_Style_Border $pStyle)
     {
-        // Create CSS
-//        $css = $this->mapBorderStyle($pStyle->getBorderStyle()) . ' #' . $pStyle->getColor()->getRGB();
-        //    Create CSS - add !important to non-none border styles for merged cells
-        $borderStyle = $this->mapBorderStyle($pStyle->getBorderStyle());
-        $css = $borderStyle . ' #' . $pStyle->getColor()->getRGB() . (($borderStyle == 'none') ? '' : ' !important');
+        // Create CSS - add !important to non-none border styles for merged cells
+        $css = $this->mapBorderStyle($pStyle->getBorderStyle());
+        
+        // If there is no border we don't want to return anything here. Actually returning
+        // border:none; would override the display of the table gridlines.
+        if ($css == 'none') {
+            return '';
+        }
+        
+        $css = $css . ' #' . $pStyle->getColor()->getRGB() . ' !important';
 
         return $css;
     }
@@ -1050,10 +1090,10 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
         // Construct HTML
         $css = array();
 
-        // Create CSS
-        $value = $pStyle->getFillType() == PHPExcel_Style_Fill::FILL_NONE ?
-            'white' : '#' . $pStyle->getStartColor()->getRGB();
-        $css['background-color'] = $value;
+        // Create CSS, if we have a fill type for this cell.
+        if ($pStyle->getFillType() != PHPExcel_Style_Fill::FILL_NONE) {
+            $css['background-color'] = '#' . $pStyle->getStartColor()->getRGB();
+        }
 
         return $css;
     }
@@ -1182,7 +1222,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
                 $coordinate = PHPExcel_Cell::stringFromColumnIndex($colNum) . ($pRow + 1);
                 if (!$this->useInlineCss) {
                     $cssClass = '';
-                    $cssClass = 'column' . $colNum;
+                    $cssClass = 'col' . $colNum;
                 } else {
                     $cssClass = array();
                     if ($cellType == 'th') {
@@ -1207,8 +1247,13 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
                     if (is_null($cell->getParent())) {
                         $cell->attach($pSheet);
                     }
+                    // Support for actual boolean values. In Excel these are always output as TRUE/FALSE, and the format cannot be changed.
+                    // By contrast you can format a numeric field as TRUE/FALSE, YES/NO, T/F, Y/N, etc, but it's not an actual boolean.
+                    if ($cell->getDataType() == 'b') {
+                        $cellData = ($cell->getValue() == 1 ? 'TRUE' : 'FALSE');
+                    }
                     // Value
-                    if ($cell->getValue() instanceof PHPExcel_RichText) {
+                    else if ($cell->getValue() instanceof PHPExcel_RichText) {
                         // Loop through rich text elements
                         $elements = $cell->getValue()->getRichTextElements();
                         foreach ($elements as $element) {
@@ -1276,8 +1321,8 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
                                 $cssClass = array_merge($cssClass, $this->cssStyles['th.style' . $cell->getXfIndex()]);
                             }
                         } else {
-                            if (isset($this->cssStyles['td.style' . $cell->getXfIndex()])) {
-                                $cssClass = array_merge($cssClass, $this->cssStyles['td.style' . $cell->getXfIndex()]);
+                            if (isset($this->cssStyles['td.style' . $cell->getXfIndex() . ',a.style' . $cell->getXfIndex()])) {
+                                $cssClass = array_merge($cssClass, $this->cssStyles['td.style' . $cell->getXfIndex() . ',a.style' . $cell->getXfIndex()]);
                             }
                         }
 
@@ -1292,7 +1337,18 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
 
                 // Hyperlink?
                 if ($pSheet->hyperlinkExists($coordinate) && !$pSheet->getHyperlink($coordinate)->isInternal()) {
-                    $cellData = '<a href="' . htmlspecialchars($pSheet->getHyperlink($coordinate)->getUrl()) . '" title="' . htmlspecialchars($pSheet->getHyperlink($coordinate)->getTooltip()) . '">' . $cellData . '</a>';
+                    $hrefStart = '<a href="' . htmlspecialchars($pSheet->getHyperlink($coordinate)->getUrl()) . '"';
+                    
+                    $tooltip = $pSheet->getHyperlink($coordinate)->getTooltip();
+                    if ($tooltip != '') {
+                      $hrefStart .= ' title="' . htmlspecialchars($tooltip) . '"';
+                    }
+                    
+                    if (!$this->useInlineCss) {
+                      $hrefStart .= ' class="' . $cssClass . '"';
+                    }
+                    
+                    $cellData = $hrefStart . '>' . $cellData . '</a>';
                 }
 
                 // Should the cell be written or is it swallowed by a rowspan or colspan?
@@ -1394,7 +1450,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
         foreach ($pValue as $property => $value) {
             $pairs[] = $property . ':' . $value;
         }
-        $string = implode('; ', $pairs);
+        $string = implode('; ', $pairs) . ';';
 
         return $string;
     }

--- a/Documentation/markdown/Overview/08-Recipes.md
+++ b/Documentation/markdown/Overview/08-Recipes.md
@@ -405,7 +405,7 @@ $objPHPExcel->getActiveSheet()->setBreak( 'D10' , PHPExcel_Worksheet::BREAK_COLU
 
 To show/hide gridlines when printing, use the following code:
 
-$objPHPExcel->getActiveSheet()->setShowGridlines(true);
+$objPHPExcel->getActiveSheet()->setPrintGridlines(true);
 
 #### Setting rows/columns to repeat at top/left
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpoffice/phpexcel",
+    "name": "computertinker/phpexcel",
     "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "http://phpexcel.codeplex.com",


### PR DESCRIPTION
* Allow comma separated chart data series values using the format:
'Worksheet Name'!$C$10,'Worksheet Name'!$C$13

* Add more color definitions to the pre-defined constant values,
limiting the expansion to combinations of the FF and 80 hex codes.

* Numerous fixes for HTML rendering: Don't output extra TR and TD at the
bottom unless either a chart or a drawing were found. Style hyperlinks
using same style info as the TD, as intended. Write unified border css
property if all of the border-* components are identical. When TD
specifies border:none, do not write out that property as it overrides
the table gridlines. When no cell background fill is specified, do not
write out a background color of white since the page background has
already been set to white. Fix a typo where the TDs were trying to
reference a non-existent 'column' class instead of the 'col' class which
is actually defined.

* Add support for proper output of boolean values and numeric values
treated as logicals.