### PR TITLE
[PHP7] Requires all list() parameters to be present

### DIFF
--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -328,7 +328,7 @@ class PHPExcel_Calculation_Functions
             return '=' . $condition;
         } else {
             preg_match('/([<>=]+)(.*)/', $condition, $matches);
-            list(, $operator, $operand) = $matches;
+            list($unusedParamA, $operator, $operand) = $matches;
 
             if (!is_numeric($operand)) {
                 $operand = str_replace('"', '""', $operand);

--- a/Classes/PHPExcel/Chart/DataSeriesValues.php
+++ b/Classes/PHPExcel/Chart/DataSeriesValues.php
@@ -306,7 +306,7 @@ class PHPExcel_Chart_DataSeriesValues
             } else {
                 $cellRange = explode('!', $this->dataSource);
                 if (count($cellRange) > 1) {
-                    list(, $cellRange) = $cellRange;
+                    list($unusedParamA, $cellRange) = $cellRange;
                 }
 
                 $dimensions = PHPExcel_Cell::rangeDimension(str_replace('$', '', $cellRange));

--- a/Classes/PHPExcel/Reader/Gnumeric.php
+++ b/Classes/PHPExcel/Reader/Gnumeric.php
@@ -289,7 +289,7 @@ class PHPExcel_Reader_Gnumeric extends PHPExcel_Reader_Abstract implements PHPEx
                             $docProps->setModified($creationDate);
                             break;
                         case 'user-defined':
-                            list(, $attrName) = explode(':', $attributes['name']);
+                            list($unusedParamA, $attrName) = explode(':', $attributes['name']);
                             switch ($attrName) {
                                 case 'publisher':
                                     $docProps->setCompany(trim($propertyValue));

--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -349,7 +349,7 @@ class PHPExcel_ReferenceHelper
         if (!empty($aRowDimensions)) {
             foreach ($aRowDimensions as $objRowDimension) {
                 $newReference = $this->updateCellReference('A' . $objRowDimension->getRowIndex(), $pBefore, $pNumCols, $pNumRows);
-                list(, $newReference) = PHPExcel_Cell::coordinateFromString($newReference);
+                list($unusedParamA, $newReference) = PHPExcel_Cell::coordinateFromString($newReference);
                 if ($objRowDimension->getRowIndex() != $newReference) {
                     $objRowDimension->setRowIndex($newReference);
                 }

--- a/Classes/PHPExcel/Shared/OLE.php
+++ b/Classes/PHPExcel/Shared/OLE.php
@@ -226,7 +226,7 @@ class PHPExcel_Shared_OLE
      */
     private static function _readInt1($fh)
     {
-        list(, $tmp) = unpack("c", fread($fh, 1));
+        list($unusedParamA, $tmp) = unpack("c", fread($fh, 1));
         return $tmp;
     }
 
@@ -238,7 +238,7 @@ class PHPExcel_Shared_OLE
      */
     private static function _readInt2($fh)
     {
-        list(, $tmp) = unpack("v", fread($fh, 2));
+        list($unusedParamA, $tmp) = unpack("v", fread($fh, 2));
         return $tmp;
     }
 
@@ -250,7 +250,7 @@ class PHPExcel_Shared_OLE
      */
     private static function _readInt4($fh)
     {
-        list(, $tmp) = unpack("V", fread($fh, 4));
+        list($unusedParamA, $tmp) = unpack("V", fread($fh, 4));
         return $tmp;
     }
 
@@ -509,8 +509,8 @@ class PHPExcel_Shared_OLE
 
         // factor used for separating numbers into 4 bytes parts
         $factor = pow(2, 32);
-        list(, $high_part) = unpack('V', substr($string, 4, 4));
-        list(, $low_part) = unpack('V', substr($string, 0, 4));
+        list($unusedParamA, $high_part) = unpack('V', substr($string, 4, 4));
+        list($unusedParamB, $low_part) = unpack('V', substr($string, 0, 4));
 
         $big_date = ($high_part * $factor) + $low_part;
         // translate to seconds


### PR DESCRIPTION
Updated all the files with missing list parameters to include a variable that would not interfere with the rest of the code. (Not that there is an expectation for v1.8 to handle PHP7)