### PR TITLE
Fixes not found error in Classes/PHPExcel/Shared/ZipArchive.php due t…

### DIFF
--- a/Classes/PHPExcel/Shared/ZipArchive.php
+++ b/Classes/PHPExcel/Shared/ZipArchive.php
@@ -1,5 +1,10 @@
 <?php
 
+if (!defined('PHPEXCEL_ROOT')){
+    define('PHPEXCEL_ROOT', dirname(__FILE__) . '/../../');
+    require(PHPEXCEL_ROOT . 'PHPExcel/Autoloader.php');
+}
+
 if (!defined('PCLZIP_TEMPORARY_DIR')) {
     define('PCLZIP_TEMPORARY_DIR', PHPExcel_Shared_File::sys_get_temp_dir() . DIRECTORY_SEPARATOR);
 }


### PR DESCRIPTION
Fixes not found error in Classes/PHPExcel/Shared/ZipArchive.php due to PHPEXCEL_ROOT not being defined

	modified:   Classes/PHPExcel/Shared/ZipArchive.php