### PR TITLE
fix docblock

### DIFF
--- a/Classes/PHPExcel/Worksheet/Row.php
+++ b/Classes/PHPExcel/Worksheet/Row.php
@@ -77,7 +77,7 @@ class PHPExcel_Worksheet_Row
      *
      * @param    string                $startColumn    The column address at which to start iterating
      * @param    string                $endColumn        Optionally, the column address at which to stop iterating
-     * @return PHPExcel_Worksheet_CellIterator
+     * @return PHPExcel_Worksheet_RowCellIterator
      */
     public function getCellIterator($startColumn = 'A', $endColumn = null)
     {


### PR DESCRIPTION
Previously annotated PHPExcel_Worksheet_CellIterator does not implement Iterator interface. In result IDE's such as a PHPstorm highlight this code as invalid:

```
foreach ($this->row->getCellIterator() as $cell) {
    // do sth
}
```

current workaround using annotations:
```
/** @var \PHPExcel_Worksheet_RowCellIterator $cellIterator */
$cellIterator = $this->row->getCellIterator();
foreach ($cellIterator as $cell) {
    // do sth
}
```

After merging this change the first example will be valid.