### PR TITLE
fix typo

### DIFF
--- a/Classes/PHPExcel/Writer/HTML.php
+++ b/Classes/PHPExcel/Writer/HTML.php
@@ -398,7 +398,7 @@ class PHPExcel_Writer_HTML extends PHPExcel_Writer_Abstract implements PHPExcel_
         }
 
         // Ensure that Spans have been calculated?
-        if ($this->_sheetIndex !== null || !$this->spansAreCalculated) {
+        if ($this->sheetIndex !== null || !$this->spansAreCalculated) {
             $this->calculateSpans();
         }
 


### PR DESCRIPTION
HTML writer has produced error
`Undefined property: PHPExcel_Writer_HTML::$_sheetIndex in vendor/phpoffice/phpexcel/Classes/PHPExcel/Writer/HTML.php:401/`
I assume there is because property `_sheetIndex` does not exists, but exists property `sheetIndex`