### PR TITLE
fixed php warning because of double call func

### DIFF
--- a/src/PhpSpreadsheet/Writer/Excel5.php
+++ b/src/PhpSpreadsheet/Writer/Excel5.php
@@ -371,7 +371,7 @@ class Excel5 extends BaseWriter implements IWriter
                     $spContainer->setOPT(0x03BF, 0x000A0000); // Group Shape -> fPrint
 
                     // set coordinates and offsets, client anchor
-                    $endCoordinates = \PHPExcel\Cell::stringFromColumnIndex(\PHPExcel\Cell::stringFromColumnIndex($iInc - 1));
+                    $endCoordinates = \PHPExcel\Cell::stringFromColumnIndex($iInc - 1);
                     $endCoordinates .= $rangeBounds[0][1] + 1;
 
                     $spContainer->setStartCoordinates($cDrawing);


### PR DESCRIPTION
Double call of for example PHPExcel_Cell::stringFromColumnIndex(PHPExcel_Cell::stringFromColumnIndex(0)) result in second call get a non numeric value, for example "A". This will raise an PHP warning error like `PHP Warning: A non-numeric value encountered in file PHPExcel\PHPExcel\Cell.php (843)
Removing this double call will fix this issues.