### PR TITLE
Fix: ConvertEncoding method try order

### DIFF
--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -486,12 +486,12 @@ class PHPExcel_Shared_String
      */
     public static function ConvertEncoding($value, $to, $from)
     {
-        if (self::getIsIconvEnabled()) {
-            return iconv($from, $to, $value);
-        }
-
         if (self::getIsMbstringEnabled()) {
             return mb_convert_encoding($value, $to, $from);
+        }
+
+        if (self::getIsIconvEnabled()) {
+            return iconv($from, $to, $value);
         }
 
         if ($from == 'UTF-16LE') {


### PR DESCRIPTION
Changed try order from [1st:iconv, 2nd:mbstring] to [1st:mbstring, 2nd:iconv] just like comment.

In order [1st:iconv, 2nd:mbstring], i got a error message 'iconv(): Detected an illegal character in input string' when i read a csv file with SJIS-WIN encoding.
It seems that iconv unable to properly convert SJIS-WIN to UTF-8.