### PR TITLE
iconv illegal character fix

### DIFF
--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -487,7 +487,7 @@ class PHPExcel_Shared_String
     public static function ConvertEncoding($value, $to, $from)
     {
         if (self::getIsIconvEnabled()) {
-            return iconv($from, $to, $value);
+            return iconv($from, $to.'//IGNORE//TRANSLIT', $value);
         }
 
         if (self::getIsMbstringEnabled()) {


### PR DESCRIPTION
This small fix will prevent 

> iconv(): Detected an illegal character in input string on line 496 of the file Classes/PHPExcel/Shared/String.php