### PR TITLE
removeColumn doesn't remove all cells

### DIFF
--- a/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
+++ b/Classes/PHPExcel/CachedObjectStorage/CacheBase.php
@@ -149,8 +149,8 @@ abstract class PHPExcel_CachedObjectStorage_CacheBase
 
         if (is_object($this->cellCache[$pCoord])) {
             $this->cellCache[$pCoord]->detach();
-            unset($this->cellCache[$pCoord]);
         }
+        unset($this->cellCache[$pCoord]);
         $this->currentCellIsDirty = false;
     }
 


### PR DESCRIPTION
removeColumn doesn't remove all cells, because CacheBase::deleteCacheData only unsets cell data if they are objects.
But cached cell data could be arrays.
I moved the unset from inside the if block (line 150 ff) to after the if block.
