### PR TITLE
Fix bug with convert int

### DIFF
--- a/Classes/PHPExcel/Shared/OLERead.php
+++ b/Classes/PHPExcel/Shared/OLERead.php
@@ -303,6 +303,8 @@ class PHPExcel_Shared_OLERead
      */
     private static function getInt4d($data, $pos)
     {
+        $len = strlen($data);
+		if ($len < $pos + 4) $data .= str_repeat("\0", $pos + 4 - $len);
         // FIX: represent numbers correctly on 64-bit system
         // http://sourceforge.net/tracker/index.php?func=detail&aid=1487372&group_id=99160&atid=623334
         // Hacked by Andreas Rehm 2006 to ensure correct result of the <<24 block on 32 and 64bit systems


### PR DESCRIPTION
Some bugged file have $data less from four bytes. This fix append zero bytes if it happens.

It is prevent errors on access to need indexes.