### PR TITLE
Fix signature detection on Excel2003XML

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -91,6 +91,7 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
         // Read sample data (first 2 KB will do)
         $data = fread($fileHandle, 2048);
         fclose($fileHandle);
+        $data = strtr($data, "'", '"'); // fix headers with single quote
 
         $valid = true;
         foreach ($signature as $match) {


### PR DESCRIPTION
Signature can be with single quotes:
```
<?xml version='1.0'?>
<?mso-application progid='Excel.Sheet'?>
```