### PR TITLE
Fix getFormattedValue error for chinese date format

### DIFF
--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -457,7 +457,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
         // strip off first part containing e.g. [$-F800] or [$USD-409]
         // general syntax: [$<Currency string>-<language info>]
         // language info is in hexadecimal
-        $format = preg_replace('/^(\[\$[A-Z]*-[0-9A-F]*\])/i', '', $format);
+        $format = preg_replace('/^(\[.*\])*(\[\$[A-Z]*-[0-9A-F]*\])/i', '', $format);
 
         // OpenOffice.org uses upper-case number formats, e.g. 'YYYY', convert to lower-case;
         //    but we don't want to change any quoted strings


### PR DESCRIPTION
the getFormattedValue() function can't get the three format of chinese correctly
[DBNum1][$-804]yyyy"年"m"月"d"日";@
[DBNum1][$-804]yyyy"年"m"月";@
[DBNum1][$-804]m"月"d"日";@

i modify the preg expression to solve this problem