### PR TITLE
Use isset() where possible, avoiding speed penality

### DIFF
--- a/Classes/PHPExcel.php
+++ b/Classes/PHPExcel.php
@@ -248,7 +248,7 @@ class PHPExcel
                 break;
             case 'target':
             case 'data':
-                if (is_array($this->ribbonXMLData) && array_key_exists($What, $this->ribbonXMLData)) {
+                if (is_array($this->ribbonXMLData) && isset($this->ribbonXMLData[$What])) {
                     $ReturnData = $this->ribbonXMLData[$What];
                 }
                 break;
@@ -292,17 +292,17 @@ class PHPExcel
                 break;
             case 'names':
             case 'data':
-                if (is_array($this->ribbonBinObjects) && array_key_exists($What, $this->ribbonBinObjects)) {
+                if (is_array($this->ribbonBinObjects) && isset($this->ribbonBinObjects[$What])) {
                     $ReturnData=$this->ribbonBinObjects[$What];
                 }
                 break;
             case 'types':
                 if (is_array($this->ribbonBinObjects) &&
-                    array_key_exists('data', $this->ribbonBinObjects) && is_array($this->ribbonBinObjects['data'])) {
-                    $tmpTypes=array_keys($this->ribbonBinObjects['data']);
+                    isset($this->ribbonBinObjects['data']) && is_array($this->ribbonBinObjects['data'])) {
+                    $tmpTypes = array_keys($this->ribbonBinObjects['data']);
                     $ReturnData = array_unique(array_map(array($this, 'getExtensionOnly'), $tmpTypes));
                 } else {
-                    $ReturnData=array(); // the caller want an array... not null if empty
+                    $ReturnData = array(); // the caller want an array... not null if empty
                 }
                 break;
         }

--- a/Classes/PHPExcel/CachedObjectStorageFactory.php
+++ b/Classes/PHPExcel/CachedObjectStorageFactory.php
@@ -180,7 +180,7 @@ class PHPExcel_CachedObjectStorageFactory
 
         self::$storageMethodParameters[$method] = self::$storageMethodDefaultParameters[$method];
         foreach ($arguments as $k => $v) {
-            if (array_key_exists($k, self::$storageMethodParameters[$method])) {
+            if (isset(self::$storageMethodParameters[$method][$k])) {
                 self::$storageMethodParameters[$method][$k] = $v;
             }
         }

--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -748,7 +748,7 @@ if ((!function_exists('mb_str_replace')) &&
             if ($s == '' && $s !== 0) {
                 continue;
             }
-            $r = !is_array($replace) ? $replace : (array_key_exists($key, $replace) ? $replace[$key] : '');
+            $r = !is_array($replace) ? $replace : (isset($replace[$key]) ? $replace[$key] : '');
             $pos = mb_strpos($subject, $s, 0, 'UTF-8');
             while ($pos !== false) {
                 $subject = mb_substr($subject, 0, $pos, 'UTF-8') . $r . mb_substr($subject, $pos + mb_strlen($s, 'UTF-8'), 65535, 'UTF-8');

--- a/Classes/PHPExcel/Calculation/MathTrig.php
+++ b/Classes/PHPExcel/Calculation/MathTrig.php
@@ -475,7 +475,7 @@ class PHPExcel_Calculation_MathTrig
                 $myPoweredFactors[$myCountedFactor] = pow($myCountedFactor, $myCountedPower);
             }
             foreach ($myPoweredFactors as $myPoweredValue => $myPoweredFactor) {
-                if (array_key_exists($myPoweredValue, $allPoweredFactors)) {
+                if (isset($allPoweredFactors[$myPoweredValue])) {
                     if ($allPoweredFactors[$myPoweredValue] < $myPoweredFactor) {
                         $allPoweredFactors[$myPoweredValue] = $myPoweredFactor;
                     }

--- a/Classes/PHPExcel/Cell/DataType.php
+++ b/Classes/PHPExcel/Cell/DataType.php
@@ -106,7 +106,7 @@ class PHPExcel_Cell_DataType
     {
         $pValue = (string) $pValue;
 
-        if (!array_key_exists($pValue, self::$errorCodes)) {
+        if (!isset(self::$errorCodes[$pValue])) {
             $pValue = '#NULL!';
         }
 

--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -93,8 +93,8 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
                 return PHPExcel_Cell_DataType::TYPE_STRING;
             }
             return PHPExcel_Cell_DataType::TYPE_NUMERIC;
-        } elseif (is_string($pValue))
-            $array = PHPExcel_Cell_DataType::getErrorCodes()
+        } elseif (is_string($pValue)) {
+            $array = PHPExcel_Cell_DataType::getErrorCodes();
             if (is_array($array) && isset($array[$pValue])) {
                 return PHPExcel_Cell_DataType::TYPE_ERROR;
             }

--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -93,8 +93,11 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
                 return PHPExcel_Cell_DataType::TYPE_STRING;
             }
             return PHPExcel_Cell_DataType::TYPE_NUMERIC;
-        } elseif (is_string($pValue) && array_key_exists($pValue, PHPExcel_Cell_DataType::getErrorCodes())) {
-            return PHPExcel_Cell_DataType::TYPE_ERROR;
+        } elseif (is_string($pValue))
+            $array = PHPExcel_Cell_DataType::getErrorCodes()
+            if (is_array($array) && isset($array[$pValue])) {
+                return PHPExcel_Cell_DataType::TYPE_ERROR;
+            }
         }
 
         return PHPExcel_Cell_DataType::TYPE_STRING;

--- a/Classes/PHPExcel/Chart/Legend.php
+++ b/Classes/PHPExcel/Chart/Legend.php
@@ -124,7 +124,7 @@ class PHPExcel_Chart_Legend
      */
     public function setPositionXL($positionXL = self::xlLegendPositionRight)
     {
-        if (!array_key_exists($positionXL, self::$positionXLref)) {
+        if (!isset(self::$positionXLref[$positionXL])) {
             return false;
         }
 

--- a/Classes/PHPExcel/Style.php
+++ b/Classes/PHPExcel/Style.php
@@ -441,25 +441,25 @@ class PHPExcel_Style extends PHPExcel_Style_Supervisor implements PHPExcel_IComp
 
             } else {
                 // not a supervisor, just apply the style array directly on style object
-                if (array_key_exists('fill', $pStyles)) {
+                if (isset($pStyles['fill'])) {
                     $this->getFill()->applyFromArray($pStyles['fill']);
                 }
-                if (array_key_exists('font', $pStyles)) {
+                if (isset($pStyles['font'])) {
                     $this->getFont()->applyFromArray($pStyles['font']);
                 }
-                if (array_key_exists('borders', $pStyles)) {
+                if (isset($pStyles['borders'])) {
                     $this->getBorders()->applyFromArray($pStyles['borders']);
                 }
-                if (array_key_exists('alignment', $pStyles)) {
+                if (isset($pStyles['alignment'])) {
                     $this->getAlignment()->applyFromArray($pStyles['alignment']);
                 }
-                if (array_key_exists('numberformat', $pStyles)) {
+                if (isset($pStyles['numberformat'])) {
                     $this->getNumberFormat()->applyFromArray($pStyles['numberformat']);
                 }
-                if (array_key_exists('protection', $pStyles)) {
+                if (isset($pStyles['protection'])) {
                     $this->getProtection()->applyFromArray($pStyles['protection']);
                 }
-                if (array_key_exists('quotePrefix', $pStyles)) {
+                if (isset($pStyles['quotePrefix'])) {
                     $this->quotePrefix = $pStyles['quotePrefix'];
                 }
             }

--- a/Classes/PHPExcel/Style/Borders.php
+++ b/Classes/PHPExcel/Style/Borders.php
@@ -222,25 +222,25 @@ class PHPExcel_Style_Borders extends PHPExcel_Style_Supervisor implements PHPExc
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('left', $pStyles)) {
+                if (isset($pStyles['left'])) {
                     $this->getLeft()->applyFromArray($pStyles['left']);
                 }
-                if (array_key_exists('right', $pStyles)) {
+                if (isset($pStyles['right'])) {
                     $this->getRight()->applyFromArray($pStyles['right']);
                 }
-                if (array_key_exists('top', $pStyles)) {
+                if (isset($pStyles['top'])) {
                     $this->getTop()->applyFromArray($pStyles['top']);
                 }
-                if (array_key_exists('bottom', $pStyles)) {
+                if (isset($pStyles['bottom'])) {
                     $this->getBottom()->applyFromArray($pStyles['bottom']);
                 }
-                if (array_key_exists('diagonal', $pStyles)) {
+                if (isset($pStyles['diagonal'])) {
                     $this->getDiagonal()->applyFromArray($pStyles['diagonal']);
                 }
-                if (array_key_exists('diagonaldirection', $pStyles)) {
+                if (isset($pStyles['diagonaldirection'])) {
                     $this->setDiagonalDirection($pStyles['diagonaldirection']);
                 }
-                if (array_key_exists('allborders', $pStyles)) {
+                if (isset($pStyles['allborders'])) {
                     $this->getLeft()->applyFromArray($pStyles['allborders']);
                     $this->getRight()->applyFromArray($pStyles['allborders']);
                     $this->getTop()->applyFromArray($pStyles['allborders']);

--- a/Classes/PHPExcel/Style/Color.php
+++ b/Classes/PHPExcel/Style/Color.php
@@ -155,10 +155,10 @@ class PHPExcel_Style_Color extends PHPExcel_Style_Supervisor implements PHPExcel
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('rgb', $pStyles)) {
+                if (isset($pStyles['rgb'])) {
                     $this->setRGB($pStyles['rgb']);
                 }
-                if (array_key_exists('argb', $pStyles)) {
+                if (isset($pStyles['argb'])) {
                     $this->setARGB($pStyles['argb']);
                 }
             }
@@ -415,7 +415,7 @@ class PHPExcel_Style_Color extends PHPExcel_Style_Supervisor implements PHPExcel
                 );
         }
 
-        if (array_key_exists($pIndex, self::$indexedColors)) {
+        if (isset(self::$indexedColors[$pIndex])) {
             return new PHPExcel_Style_Color(self::$indexedColors[$pIndex]);
         }
 

--- a/Classes/PHPExcel/Style/Fill.php
+++ b/Classes/PHPExcel/Style/Fill.php
@@ -157,19 +157,19 @@ class PHPExcel_Style_Fill extends PHPExcel_Style_Supervisor implements PHPExcel_
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('type', $pStyles)) {
+                if (isset($pStyles['type'])) {
                     $this->setFillType($pStyles['type']);
                 }
-                if (array_key_exists('rotation', $pStyles)) {
+                if (isset($pStyles['rotation'])) {
                     $this->setRotation($pStyles['rotation']);
                 }
-                if (array_key_exists('startcolor', $pStyles)) {
+                if (isset($pStyles['startcolor'])) {
                     $this->getStartColor()->applyFromArray($pStyles['startcolor']);
                 }
-                if (array_key_exists('endcolor', $pStyles)) {
+                if (isset($pStyles['endcolor'])) {
                     $this->getEndColor()->applyFromArray($pStyles['endcolor']);
                 }
-                if (array_key_exists('color', $pStyles)) {
+                if (isset($pStyles['color'])) {
                     $this->getStartColor()->applyFromArray($pStyles['color']);
                 }
             }

--- a/Classes/PHPExcel/Style/Font.php
+++ b/Classes/PHPExcel/Style/Font.php
@@ -182,31 +182,31 @@ class PHPExcel_Style_Font extends PHPExcel_Style_Supervisor implements PHPExcel_
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('name', $pStyles)) {
+                if (isset($pStyles['name'])) {
                     $this->setName($pStyles['name']);
                 }
-                if (array_key_exists('bold', $pStyles)) {
+                if (isset($pStyles['bold'])) {
                     $this->setBold($pStyles['bold']);
                 }
-                if (array_key_exists('italic', $pStyles)) {
+                if (isset($pStyles['italic'])) {
                     $this->setItalic($pStyles['italic']);
                 }
-                if (array_key_exists('superScript', $pStyles)) {
+                if (isset($pStyles['superScript'])) {
                     $this->setSuperScript($pStyles['superScript']);
                 }
-                if (array_key_exists('subScript', $pStyles)) {
+                if (isset($pStyles['subScript'])) {
                     $this->setSubScript($pStyles['subScript']);
                 }
-                if (array_key_exists('underline', $pStyles)) {
+                if (isset($pStyles['underline'])) {
                     $this->setUnderline($pStyles['underline']);
                 }
-                if (array_key_exists('strike', $pStyles)) {
+                if (isset($pStyles['strike'])) {
                     $this->setStrikethrough($pStyles['strike']);
                 }
-                if (array_key_exists('color', $pStyles)) {
+                if (isset($pStyles['color'])) {
                     $this->getColor()->applyFromArray($pStyles['color']);
                 }
-                if (array_key_exists('size', $pStyles)) {
+                if (isset($pStyles['size'])) {
                     $this->setSize($pStyles['size']);
                 }
             }

--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -159,7 +159,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('code', $pStyles)) {
+                if (isset($pStyles['code'])) {
                     $this->setFormatCode($pStyles['code']);
                 }
             }

--- a/Classes/PHPExcel/Writer/Excel2007/Style.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Style.php
@@ -620,7 +620,7 @@ class PHPExcel_Writer_Excel2007_Style extends PHPExcel_Writer_Excel2007_WriterPa
         // The remaining fills
         $aStyles = $this->allStyles($pPHPExcel);
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getFill()->getHashCode(), $aFills)) {
+            if (!isset($aFills[$style->getFill()->getHashCode()])) {
                 $aFills[ $style->getFill()->getHashCode() ] = $style->getFill();
             }
         }
@@ -642,7 +642,7 @@ class PHPExcel_Writer_Excel2007_Style extends PHPExcel_Writer_Excel2007_WriterPa
         $aStyles = $this->allStyles($pPHPExcel);
 
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getFont()->getHashCode(), $aFonts)) {
+            if (!isset($aFonts[$style->getFont()->getHashCode()])) {
                 $aFonts[ $style->getFont()->getHashCode() ] = $style->getFont();
             }
         }
@@ -664,7 +664,7 @@ class PHPExcel_Writer_Excel2007_Style extends PHPExcel_Writer_Excel2007_WriterPa
         $aStyles = $this->allStyles($pPHPExcel);
 
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getBorders()->getHashCode(), $aBorders)) {
+            if (!isset($aBorders[$style->getBorders()->getHashCode()])) {
                 $aBorders[ $style->getBorders()->getHashCode() ] = $style->getBorders();
             }
         }
@@ -686,7 +686,7 @@ class PHPExcel_Writer_Excel2007_Style extends PHPExcel_Writer_Excel2007_WriterPa
         $aStyles = $this->allStyles($pPHPExcel);
 
         foreach ($aStyles as $style) {
-            if ($style->getNumberFormat()->getBuiltInFormatCode() === false && !array_key_exists($style->getNumberFormat()->getHashCode(), $aNumFmts)) {
+            if ($style->getNumberFormat()->getBuiltInFormatCode() === false && !isset($aNumFmts[$style->getNumberFormat()->getHashCode()])) {
                 $aNumFmts[ $style->getNumberFormat()->getHashCode() ] = $style->getNumberFormat();
             }
         }

--- a/Classes/PHPExcel/Writer/Excel5/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel5/Worksheet.php
@@ -853,7 +853,8 @@ class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
                 // Numeric value
                 $num = pack('d', $calculatedValue);
             } elseif (is_string($calculatedValue)) {
-                if (array_key_exists($calculatedValue, PHPExcel_Cell_DataType::getErrorCodes())) {
+                $array = PHPExcel_Cell_DataType::getErrorCodes();
+                if (is_array($array) && isset($array[$calculatedValue])) {
                     // Error value
                     $num = pack('CCCvCv', 0x02, 0x00, self::mapErrorCode($calculatedValue), 0x00, 0x00, 0xFFFF);
                 } elseif ($calculatedValue === '') {


### PR DESCRIPTION
`array_key_exists()` is much slower (around 2-3 times) than `isset()` and should only be used if (small) arrays are being tested if a NULL-ed key should exists. Else it should be avoided.

`array_key_exists()` iterates over the whole (but not recursive) array and searches for the key. That is why it is slow and finds keys with NULL values. `isset()` in constrast only checks if the given key exists.

Yes, the later one can be (ab)used for testing on strings but that may vanish.

http://de.php.net/array_key_exists
http://de.php.net/isset