### PR TITLE
Excel2003 XML parse Interior Pattern property

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -492,6 +492,9 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
                                 case 'Color':
                                     $this->styles[$styleID]['fill']['color']['rgb'] = substr($styleAttributeValue, 1);
                                     break;
+                                case 'Pattern':
+                                    $this->styles[$styleID]['fill']['type'] = substr($styleAttributeValue, 1);
+                                    break;
                             }
                         }
                         break;


### PR DESCRIPTION
Enable Interior Pattern property for Excel2003 XML. 