### PR TITLE
Conditional added when using PCLZIP as ZipClass

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -309,14 +309,21 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 
         // Sadly, some 3rd party xlsx generators don't use consistent case for filenaming
         //    so we need to load case-insensitively from the zip file
-        
+
         // Apache POI fixes
-        $contents = $archive->getFromIndex(
-            $archive->locateName($fileName, ZIPARCHIVE::FL_NOCASE)
-        );
-        if ($contents === false) {
+        if ('ZipArchive' == PHPExcel_Settings::getZipClass()) {
             $contents = $archive->getFromIndex(
-                $archive->locateName(substr($fileName, 1), ZIPARCHIVE::FL_NOCASE)
+                $archive->locateName($fileName, ZIPARCHIVE::FL_NOCASE)
+            );
+            if ($contents === false) {
+                $contents = $archive->getFromIndex(
+                    $archive->locateName(substr($fileName, 1), ZIPARCHIVE::FL_NOCASE)
+                );
+            }
+        }
+        else {
+            $contents = $archive->getFromIndex(
+                $archive->locateName($fileName)
             );
         }
 


### PR DESCRIPTION
PHPExcel_Settings::setZipClass(PHPExcel_Settings::PCLZIP);
$php_excel = PHPExcel_IOFactory::load($excel_file);

Fatal error: Uncaught Error: Class 'ZIPARCHIVE' not found in PHPExcel/Reader/Excel2007.php:314