### PR TITLE
Properly format non-integer font sizes

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Style.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Style.php
@@ -318,7 +318,7 @@ class PHPExcel_Writer_Excel2007_Style extends PHPExcel_Writer_Excel2007_WriterPa
         // Size
         if ($pFont->getSize() !== null) {
             $objWriter->startElement('sz');
-            $objWriter->writeAttribute('val', $pFont->getSize());
+            $objWriter->writeAttribute('val', PHPExcel_Shared_String::FormatNumber($pFont->getSize()));
             $objWriter->endElement();
         }
 


### PR DESCRIPTION
The OOXML spec defines the font sizes (the `sz` element) as a double, so the value needs to be wrapped in `PHPExcel_Shared_String::FormatNumber()` to avoid breaking in non-English locales.