### PR TITLE
Note on PHP 5.6.29 and SQLite3 caching bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,7 @@ Develop: [![Build Status](https://travis-ci.org/PHPOffice/PHPExcel.png?branch=de
 
 ## Want to contribute?
 
-If you would like to contribute, here are some notes and guidlines:
- - All new development happens on the 1.8 branch, so it is always the most up-to-date
- - The master branch only contains tagged releases
- - If you are going to be submitting a pull request, please fork from 1.8, and submit your pull request back to that 1.8 branch
- - Wherever possible, code changes should conform as closely as possible to PSR-2 standards
- - [Helpful article about forking](https://help.github.com/articles/fork-a-repo/ "Forking a Github repository")
- - [Helpful article about pull requests](https://help.github.com/articles/using-pull-requests/ "Pull Requests")
+PHPExcel developement for next version has moved under its new name PhpSpreadsheet. So please head over to [PhpSpreadsheet](https://github.com/PHPOffice/PhpSpreadsheet#want-to-contribute) to contribute patches and features.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Develop: [![Build Status](https://travis-ci.org/PHPOffice/PHPExcel.png?branch=de
  * PHP extension php_xml enabled
  * PHP extension php_gd2 enabled (optional, but required for exact column width autocalculation)
 
+*Note:* PHP 5.6.29 has [a bug](https://bugs.php.net/bug.php?id=735300) that
+prevents SQLite3 caching to work correctly. Use a newer (or older) versions of
+PHP if you need SQLite3 caching.
 
 ## Want to contribute?
 


### PR DESCRIPTION
 ## Requirements

-     PHP version 5.2.0 or higher
      Note on PHP 5.6.29: this version of PHP contains a bug with SQLite3 handling,
      so the PHPExcel caching method SQLite3 does not work in this environment.
-     PHP extension php_zip enabled (required if you need PHPExcel to handle .xlsx .ods or .gnumeric files)
-     PHP extension php_xml enabled
-     PHP extension php_gd2 enabled (optional, but required for exact column width autocalculation)
