### PR TITLE
Fix "Dividion by zero" error on try format as fractional value

### DIFF
--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -514,6 +514,10 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
         $decimalDivisor = pow(10, $decimalLength);
 
         $GCD = PHPExcel_Calculation_MathTrig::GCD($decimalPart, $decimalDivisor);
+        
+        if (!is_numeric($GCD) || $GCD == 0) {
+		    return;
+	    }
 
         $adjustedDecimalPart = $decimalPart/$GCD;
         $adjustedDecimalDivisor = $decimalDivisor/$GCD;


### PR DESCRIPTION
$value = 1234.0;    
$format = '# ?/?';   
Call     private static function formatAsFraction(&$value, &$format)   
$decimalPart = '';   
$decimalDivisor = 1;   
$GCD = PHPExcel_Calculation_MathTrig::GCD($decimalPart,$decimalDivisor);   
$GCD = '#Value!';   
As result   
$adjustedDecimalPart = $decimalPart/$GCD;   
$adjustedDecimalDivisor = $decimalDivisor/$GCD;  
return division by zero.   
It caused because $GCD calculated from $decimalPart = ''; but if we use zero instead of empty string this is get next result:
$value = "1234 0/1";
But in Excel this never happen. In Excel this look like "1234    ". It is similar to initial value. Then we can use simple return without change value if that happens.