### PR TITLE
Check for DateTimeInterface in order to support DateTimeImmutable

### DIFF
--- a/Classes/PHPExcel/Calculation/DateTime.php
+++ b/Classes/PHPExcel/Calculation/DateTime.php
@@ -98,7 +98,7 @@ class PHPExcel_Calculation_DateTime
                 (PHPExcel_Calculation_Functions::getCompatibilityMode() == PHPExcel_Calculation_Functions::COMPATIBILITY_GNUMERIC)) {
                 return PHPExcel_Calculation_Functions::VALUE();
             }
-            if ((is_object($dateValue)) && ($dateValue instanceof DateTime)) {
+            if ((is_object($dateValue)) && ($dateValue instanceof DateTimeInterface)) {
                 $dateValue = PHPExcel_Shared_Date::PHPToExcel($dateValue);
             } else {
                 $saveReturnDateType = PHPExcel_Calculation_Functions::getReturnDateType();

--- a/Classes/PHPExcel/Shared/Date.php
+++ b/Classes/PHPExcel/Shared/Date.php
@@ -188,7 +188,7 @@ class PHPExcel_Shared_Date
             0;
 
         $retValue = false;
-        if ((is_object($dateValue)) && ($dateValue instanceof DateTime)) {
+        if ((is_object($dateValue)) && ($dateValue instanceof DateTimeInterface)) {
             $dateValue->add(new DateInterval('PT' . $timezoneAdjustment . 'S'));
             $retValue = self::FormattedPHPToExcel($dateValue->format('Y'), $dateValue->format('m'), $dateValue->format('d'), $dateValue->format('H'), $dateValue->format('i'), $dateValue->format('s'));
         } elseif (is_numeric($dateValue)) {


### PR DESCRIPTION
Currently if a value is a DateTime object, it gets converted into a date, however if it is a DateTimeImmutable, it won't be parsed as a date.

By checking if a value implements an interface, we cover both cases.