### PR TITLE
Use modification time from properties when saving Excel5

### DIFF
--- a/Classes/PHPExcel/Writer/Excel5.php
+++ b/Classes/PHPExcel/Writer/Excel5.php
@@ -209,7 +209,8 @@ class PHPExcel_Writer_Excel5 extends PHPExcel_Writer_Abstract implements PHPExce
             $arrRootData[] = $OLE_DocumentSummaryInformation;
         }
 
-        $root = new PHPExcel_Shared_OLE_PPS_Root(time(), time(), $arrRootData);
+        $time = $this->phpExcel->getProperties()->getModified();
+        $root = new PHPExcel_Shared_OLE_PPS_Root($time, $time, $arrRootData);
         // save the OLE file
         $res = $root->save($pFilename);
 


### PR DESCRIPTION
The hardcoded `time()` in the Excel5 writer causes the file to change every time it is saved, even if the creation and modification dates change. This messes with change tracking.

This change makes replaces the calls to `time()` with usage of `getModified()`.