### PR TITLE
Fixed Segmentation fault when reading big xlsx files.

### DIFF
--- a/Classes/PHPExcel/Reader/Excel2007.php
+++ b/Classes/PHPExcel/Reader/Excel2007.php
@@ -642,7 +642,13 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
                             //        reverse
                             $docSheet->setTitle((string) $eleSheet["name"], false);
                             $fileWorksheet = $worksheets[(string) self::getArrayItem($eleSheet->attributes("http://schemas.openxmlformats.org/officeDocument/2006/relationships"), "id")];
-                            $xmlSheet = simplexml_load_string($this->securityScan($this->getFromZipArchive($zip, "$dir/$fileWorksheet")), 'SimpleXMLElement', PHPExcel_Settings::getLibXmlLoaderOptions());  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+                            $xmlString = $this->securityScan($this->getFromZipArchive($zip, "$dir/$fileWorksheet"));
+                            if (!xml_parse($parser = xml_parser_create(), $xmlString)) {
+                                throw new PHPExcel_Reader_Exception(xml_error_string(xml_get_error_code($parser)));
+                            }
+
+                            $xmlSheet = simplexml_load_string($xmlString, 'SimpleXMLElement', PHPExcel_Settings::getLibXmlLoaderOptions());  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+
 
                             $sharedFormulas = array();
 


### PR DESCRIPTION
When reading 19.02MB XLSX file I encouter **Segmentation fault**.
The problem when loading string into **simplexml_load_string()**.

Solution: Added XML parser **xml_parse()**, if it fails - throws error with xml error.

Now I get **No memory** xml error.