### PR TITLE
Removed an error for zoom scale in favor of a default value. 

### DIFF
--- a/Classes/PHPExcel/Worksheet/SheetView.php
+++ b/Classes/PHPExcel/Worksheet/SheetView.php
@@ -99,7 +99,7 @@ class PHPExcel_Worksheet_SheetView
         if (($pValue >= 1) || is_null($pValue)) {
             $this->zoomScale = $pValue;
         } else {
-            throw new PHPExcel_Exception("Scale must be greater than or equal to 1.");
+            $this->zoomScale = 100;
         }
         return $this;
     }
@@ -128,7 +128,7 @@ class PHPExcel_Worksheet_SheetView
         if (($pValue >= 1) || is_null($pValue)) {
             $this->zoomScaleNormal = $pValue;
         } else {
-            throw new PHPExcel_Exception("Scale must be greater than or equal to 1.");
+            $this->zoomScaleNormal = 100;
         }
         return $this;
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "phpoffice/phpexcel",
-    "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine - This fork sets a default value for zoom scale rather than returning an error",
+    "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP",
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "https://github.com/PHPOffice/PHPExcel",
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jleslie/phpexcel",
+    "name": "phpoffice/phpexcel",
     "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine - This fork sets a default value for zoom scale rather than returning an error",
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "https://github.com/PHPOffice/PHPExcel",
@@ -20,9 +20,6 @@
         },
         {
             "name": "Erik Tilt"
-        },
-        {
-            "name": "James Leslie"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "phpoffice/phpexcel",
-    "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP",
+    "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "https://github.com/PHPOffice/PHPExcel",
     "type": "library",


### PR DESCRIPTION
This error prevents files from going through when in reality it might better to simply default the value on something like zoom scale.  The end users of software made using PHPExcel will not know how to handle an error like this.