### PR TITLE
Issue #1355 (https://github.com/PHPOffice/PHPExcel/issues/1355)

### DIFF
--- a/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
+++ b/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
@@ -1726,6 +1726,7 @@ class PclZip
         $v_memory_limit = ini_get('memory_limit');
         $v_memory_limit = trim($v_memory_limit);
         $last = strtolower(substr($v_memory_limit, -1));
+        $v_memory_limit = preg_replace('/\s*[KkMmGg]$/', '', $v_memory_limit);
 
         if ($last == 'g') {
             //$v_memory_limit = $v_memory_limit*1024*1024*1024;


### PR DESCRIPTION
Remove the trailing size suffix indicator