### PR TITLE
Fix trim in pclzip.lib

### DIFF
--- a/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
+++ b/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
@@ -1724,7 +1724,7 @@ class PclZip
 
         // ----- Get 'memory_limit' configuration value
         $v_memory_limit = ini_get('memory_limit');
-        $v_memory_limit = trim($v_memory_limit);
+        $v_memory_limit = trim($v_memory_limit, 'GMK');
         $last = strtolower(substr($v_memory_limit, -1));
 
         if ($last == 'g') {


### PR DESCRIPTION
This fixes the PHP warning:

`Notice: A non well formed numeric value encountered in PclZip->privOptionDefaultThreshold() (line 1737 of sites/all/libraries/PHPExcel/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php).`

That is produced when this option is applied:
`
\PHPExcel_Settings::setZipClass(\PHPExcel_Settings::PCLZIP);`