### PR TITLE
Compatible PHP7.2 count() AutoFilter on Excel 2007

### DIFF
--- a/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Worksheet.php
@@ -768,7 +768,7 @@ class PHPExcel_Writer_Excel2007_Worksheet extends PHPExcel_Writer_Excel2007_Writ
             $objWriter->writeAttribute('ref', str_replace('$', '', $range));
 
             $columns = $pSheet->getAutoFilter()->getColumns();
-            if (count($columns > 0)) {
+            if (count($columns) > 0) {
                 foreach ($columns as $columnID => $column) {
                     $rules = $column->getRules();
                     if (count($rules) > 0) {


### PR DESCRIPTION
Avoid error emit on using autoFilter on Excel 2007 writer
`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in 
 ... vendor\phpoffice\phpexcel\Classes\PHPExcel\Writer\Excel2007\Worksheet.php on line 768`